### PR TITLE
Doc typos and header on auth section

### DIFF
--- a/docs/advanced_config.rst
+++ b/docs/advanced_config.rst
@@ -35,6 +35,9 @@ seperate::
     auth_0 = drio.Authenticator(session_key="my_unique_session_0")
     auth_1 = drio.Authenticator(session_key="my_unique_session_1")
 
+Service account / non-interactive client
+----------------------------------------
+
 If you require client/backend type of authentication flow where user interaction
 is not feasible nor desired, you can use the
 :py:class:`authenticate.ClientAuthenticator`::


### PR DESCRIPTION
Typo fixes.

Create a more separate section for the service account/non-interactive client authentication.