### PR TITLE
Case 24071: Allow file process status monitoring to be skipped in create and append

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -97,7 +97,7 @@ class Client:
         """
         return self._files_api.ping()
 
-    def create(self, series=None, force_commit=False):
+    def create(self, series=None, wait_on_verification=True):
         """
         Create a new series in DataReservoir.io from a pandas.Series. If no
         data is provided, an empty series is created.
@@ -107,14 +107,16 @@ class Client:
         series : pandas.Series, optional
             Series with index (as DatetimeIndex-like or integer array). Default
             is None.
-        force_commit : bool (optional)
-            All series are subjected to a server-side data validation before they are made available for
-            consumption; failing validation will result in the series being ignored. If False, the
-            method will wait for the data validation process to be completed and return the outcome, which
-            may be time consuming. If True, the method will NOT wait for the outcome and the data will be
-            available when/if the validation is successful. The latter is significantly faster, but is recommended
-            when the data are "validated" in advance. Default is False.
-            
+        wait_on_verification : bool (optional)
+            All series are subjected to a server-side data validation before
+            they are made available for consumption; failing validation will
+            result in the series being ignored. If True, the method will wait
+            for the data validation process to be completed and return the
+            outcome, which may be time consuming. If False, the method will NOT
+            wait for the outcome and the data will be available when/if the
+            validation is successful. The latter is significantly faster, but
+            is recommended when the data is "validated" in advance.
+            Default is True.
 
         Returns
         -------
@@ -133,7 +135,7 @@ class Client:
         time_upload = timeit.default_timer()
         log.info("Upload took {} seconds".format(time_upload - time_start), "create")
 
-        if not force_commit:
+        if wait_on_verification:
             status = self._wait_until_file_ready(file_id)
             time_process = timeit.default_timer()
             log.info(
@@ -153,7 +155,7 @@ class Client:
         )
         return response
 
-    def append(self, series, series_id, force_commit=False):
+    def append(self, series, series_id, wait_on_verification=True):
         """
         Append data to an already existing series.
 
@@ -163,13 +165,16 @@ class Client:
             Series with index (as DatetimeIndex-like or integer array).
         series_id : string
             The identifier of the existing series.
-            All series are subjected to a server-side data validation before they are made available for
-            consumption; failing validation will result in the series being ignored. If False, the
-            method will wait for the data validation process to be completed and return the outcome, which
-            may be time consuming. If True, the method will NOT wait for the outcome and the data will be
-            available when/if the validation is successful. The latter is significantly faster, but is recommended
-            when the data are "validated" in advance. Default is False.
-            
+        wait_on_verification : bool (optional)
+            All series are subjected to a server-side data validation before
+            they are made available for consumption; failing validation will
+            result in the series being ignored. If True, the method will wait
+            for the data validation process to be completed and return the
+            outcome, which may be time consuming. If False, the method will NOT
+            wait for the outcome and the data will be available when/if the
+            validation is successful. The latter is significantly faster, but
+            is recommended when the data is "validated" in advance.
+            Default is True.
 
         Returns
         -------
@@ -183,7 +188,7 @@ class Client:
         time_upload = timeit.default_timer()
         log.info("Upload took {} seconds".format(time_upload - time_start), "append")
 
-        if not force_commit:
+        if wait_on_verification:
             status = self._wait_until_file_ready(file_id)
             time_process = timeit.default_timer()
             log.info(

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -109,15 +109,21 @@ Data that have been uploaded to `DataReservoir.io`_ will always go through a
 validation process before it is made part of the series. 
 By default, :py:func:`Client.create` and :py:func:`Client.append` will wait for
 this validation process to complete successfully before appending the data to
-the timeseres. This behavior can be changed using the force_commit parameter:
+the timeseres. This behavior can be changed using the wait_on_verification parameter:
 
-    response = client.create(series, force_commit=True)
+    response = client.create(series, wait_on_verification=False)
 
-    response = client.append(series, series_id, force_commit=True)
+    response = client.append(series, series_id, wait_on_verification=False)
 
 The result is that the data is queued for processing and the method returns
 immediately. When the validation process eventually completes, the data will
 be made available on the series.
+
+.. important::
+
+    Setting `wait_on_verification` to `False` is significantly faster, but is
+    only recommended when the data is "validated" in advance. If the data
+    should not pass the server-side validation the data will be ignored.
 
 
 Access existing data

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -208,14 +208,14 @@ class Test_Client(unittest.TestCase):
         self.assertDictEqual(response, expected_response)
 
     @patch("time.sleep")
-    def test_create_with_data_with_force_commit(self, mock_sleep):
+    def test_create_with_data_without_wait_on_verification(self, mock_sleep):
         self._storage.put = Mock(return_value=self.dummy_params["FileId"])
         self.client._wait_until_file_ready = Mock(return_value="Ready")
 
         expected_response = {"abc": 123}
         self.client._timeseries_api.create_with_data.return_value = expected_response
 
-        response = self.client.create(self.dummy_df, force_commit=True)
+        response = self.client.create(self.dummy_df, wait_on_verification=False)
 
         self._storage.put.assert_called_once_with(self.dummy_df)
         self.client._wait_until_file_ready.assert_not_called()
@@ -256,7 +256,7 @@ class Test_Client(unittest.TestCase):
         self.assertDictEqual(response, expected_response)
 
     @patch("time.sleep")
-    def test_append_with_force_commit(self, mock_sleep):
+    def test_append_without_wait_on_verification(self, mock_sleep):
         self.client._verify_and_prepare_series = Mock(return_value=None)
         self._storage.put = Mock(return_value=self.dummy_params["FileId"])
         self.client._wait_until_file_ready = Mock(return_value="Ready")
@@ -265,7 +265,7 @@ class Test_Client(unittest.TestCase):
         self.client._timeseries_api.add.return_value = expected_response
 
         response = self.client.append(
-            self.dummy_df, self.timeseries_id, force_commit=True
+            self.dummy_df, self.timeseries_id, wait_on_verification=False
         )
 
         self.client._verify_and_prepare_series.assert_called_once_with(self.dummy_df)


### PR DESCRIPTION
The Reservoir API is now allowing files to be uploaded, and subsequently appended to a timeseries before processing is complete. The `client.create` and `client.append` methods have a new parameter `verify_status` that control whether the client should wait for file processing to complete before the data is appended to the timeseries. For now we are keeping the original behavior of waiting for status as default, so that users will have to opt into the new behavior.