### PR TITLE
Case 21956 - Upgrade Azure Storage library to V12

### DIFF
--- a/datareservoirio/storage/storage_engine.py
+++ b/datareservoirio/storage/storage_engine.py
@@ -8,7 +8,7 @@ from time import sleep
 import numpy as np
 import pandas as pd
 from azure.common import AzureException
-from azure.storage.blob import BlobClient
+import azure.storage.blob
 
 log = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ class AzureBlobService():
                 * 'SasKey'
                 * 'Container' (container_name)
                 * 'Path' (blob_name)
+                * 'Endpoint'
         :param: requests.Session session
             If specified, passed to the underlying BlockBlobService so that an existing
             request session can be reused.
@@ -44,11 +45,16 @@ class AzureBlobService():
 
         self._account = params["Account"]
         self._sas_key = params["SasKey"]
+        self._blob_sas_url = params["Endpoint"]
         self.container_name = params["Container"]
         self.blob_name = params["Path"]
 
-        self._blob_client = BlobClient.from_blob_url(self.blob_name)
-        # TODO: how to request_session=session
+        self._blob_client = BlockBlobService(
+            account_name=self._account,
+            sas_token=self._sas_key,
+            request_session=session
+        )
+
 
     def get_blob_to_df(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests_integration"]),
     project_urls={"Documentation": "https://www.datareservoir.io/python/docs/latest/"},
     install_requires=[
-        "azure-storage-blob>=12.5.0,<13.0.0",
+        "azure-storage-blob>=12.6.0,<13.0.0",
         "numpy",
         "oauthlib",
         "pandas>=0.24.0",

--- a/tests/test_storage/test_storage_engine.py
+++ b/tests/test_storage/test_storage_engine.py
@@ -22,6 +22,7 @@ class Test_AzureBlobService(unittest.TestCase):
             "Path": "blob_xy",
             "FileId": "file_123abc",
             "SasKey": "sassykeiz",
+            "Endpoint": "https://account_xyz/blobcontainer/blob_xy?sassykeiz"
         }
 
     def test_constructor(self):


### PR DESCRIPTION
Latest (v12.0.0) azure.storage Python API introduces breaking changes, which makes it non-trivial to update from the current API version (2.1.0).

Due to the nature of Python, everyone relying on DRIO will also be stuck with an outdated azure-storage API. This can cause much headache downstream!

### Versioning
When this change is released, the package minor version must be incremented.