### PR TITLE
Fix - Case 24935 - Restrict pyarrow version to <3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "numpy",
         "oauthlib",
         "pandas>=0.24.0",
-        "pyarrow",
+        "pyarrow<3.0.0",
         "requests",
         "requests-oauthlib",
     ],


### PR DESCRIPTION
pyarrow 3 causes issues on Windows. Limit DRIO to latest version 2 until pyarrow 3 is fixed