### PR TITLE
hotfix: disable multi-threading when downloading file chunks

### DIFF
--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -132,7 +132,7 @@ class BaseDownloader:
         if not chunks:
             return pd.DataFrame()
 
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=1) as executor:
             filechunks = executor.map(self._download_verified_chunk, chunks)
         df_chunks = pd.concat(filechunks)
         return df_chunks


### PR DESCRIPTION
`drio` implements multi-threading when downloading file chunks. This implementation was historically thought to be triggered only seldom since files where mostly 1 chunk. However, the multi-threading is almost triggered all the time now with the increase of streaming data, and those being presented at a single file with endless chunks.

The current multi-threading dispatches new workers aggressively (cores + 4). A single thread downloads and loads the stream into memory as df. The process of loading the stream into df will not release the GIL and thus creates a bottle neck. This causes started connections to Azure to put on hold, which are then forcefully disconnected by remote.

The hotfix is to disable multi-threading as the service has evolved. A more permanent re-design is required in the long run. However, this fix will resolve the issues where downloading "large" files fail. Some perf hit may occur. 