### PR TITLE
Bug fix for metadata search and browse methods 

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -207,10 +207,10 @@ class Client:
     def search(self, namespace, key=None, name=None, value=None):
         """
         Find available series having metadata with given
-        namespace + key* + name + value (optional) combination. Note that the
-        arguments are hierarchical, starting from the left. If an argument is
-        None, the proceeding ones are also set to None. For example,
-        (namespace = “hello”, key=None, name=”Rabbit”, value=”Hole”)
+        namespace + key* (optional) + name (optional) + *value* (optional) 
+        combination. Note that the arguments are hierarchical, starting from 
+        the left. If an argument is None, the proceeding ones are also set to 
+        None. For example, (namespace = “hello”, key=None, name=”Rabbit”, value=”Hole”)
         will have the same effect as (namespace = “hello”, key=None, name=None,
         value=None)
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -1,10 +1,10 @@
 import logging
 import time
 import timeit
+import warnings
 
 import pandas as pd
 import requests
-import warnings
 
 from .rest_api import FilesAPI, MetadataAPI, TimeSeriesAPI
 from .storage import (
@@ -207,9 +207,9 @@ class Client:
     def search(self, namespace, key=None, name=None, value=None):
         """
         Find available series having metadata with given
-        namespace + key* (optional) + name (optional) + *value* (optional) 
-        combination. Note that the arguments are hierarchical, starting from 
-        the left. If an argument is None, the proceeding ones are also set to 
+        namespace + key* (optional) + name (optional) + *value* (optional)
+        combination. Note that the arguments are hierarchical, starting from
+        the left. If an argument is None, the proceeding ones are also set to
         None. For example, (namespace = “hello”, key=None, name=”Rabbit”, value=”Hole”)
         will have the same effect as (namespace = “hello”, key=None, name=None,
         value=None)
@@ -217,7 +217,7 @@ class Client:
         Parameters
         ----------
         namespace : str
-            Full namespace to search for 
+            Full namespace to search for
         key : str, optional
             Key or partial (begins with) key to narrow search.
             Default (None) will include all.
@@ -225,22 +225,24 @@ class Client:
             Full name to narrow search further.
             Default (None) will include all.
         value: str, optional
-            Value or partial (begins or ends with or both) to narrow search further. 
+            Value or partial (begins or ends with or both) to narrow search further.
             Default (None) will include all.
 
         Returns
         -------
         dict or list
             Available information about the series. If ``value`` is passed,
-            a plain list with ``TimeSeriesId`` is returned. Otherwise, a dict is 
+            a plain list with ``TimeSeriesId`` is returned. Otherwise, a dict is
             returned -> ``{TimeSeriesId: metadata}``.
 
         """
-        args_ =  [namespace, key, name, value]
+        args_ = [namespace, key, name, value]
         none_count = args_.count(None)
-    
+
         if args_[-none_count:].count(None) < none_count:
-            warnings.warn('Warning: You have provided argument(s) following a None argument, they are ignored by the search!')
+            warnings.warn(
+                "Warning: You have provided argument(s) following a None argument, they are ignored by the search!"
+            )
 
         return self._timeseries_api.search(namespace, key, name, value)
 
@@ -448,8 +450,8 @@ class Client:
     def metadata_browse(self, namespace=None):
         """
         List available metadata namespaces and keys. If namespace is None, a list
-        of all available namespaces is returned. If namespace is specified, 
-        a list of all available keys for that namespace is returned. 
+        of all available namespaces is returned. If namespace is specified,
+        a list of all available keys for that namespace is returned.
 
         Parameters
         ----------
@@ -459,7 +461,7 @@ class Client:
         Returns
         -------
         list
-            The namespaces or keys found. 
+            The namespaces or keys found.
         """
 
         if not namespace:
@@ -474,7 +476,7 @@ class Client:
         namespace : string
             The namespace to search in
         key : string
-            The key to narrow search. Supports "begins with" specification, 
+            The key to narrow search. Supports "begins with" specification,
             i.e. will look for matches with "key + wildcard"
 
         Returns

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -447,7 +447,12 @@ class Client:
 
     def metadata_browse(self, namespace=None, key=None):
         """
-        Browse available metadata namespace/key/names combinations.
+        Browse available metadata namespace/key combinations. Note that the 
+        arguments are hierarchical, starting from the left. If "namespace" is 
+        None, "key" is also set to None. For example, 
+        (namespace=None, key="somekey") will have the same effect as 
+        (namespace=None, key=None), i.e. list all available namespaces.
+
 
         Parameters
         ----------

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -206,7 +206,17 @@ class Client:
     def search(self, namespace, key=None, name=None, value=None):
         """
         Find available series having metadata with given
-        namespace + key* + name + value (optional) combination.
+        namespace + key* + name + value (optional) combination. Note that if an argument is None, the proceeding ones are also set to None. For example, 
+        (namespace = “hello”, key=None, name=”Rabbit”, value=”Hole”) will have the same effect as (namespace = “hello”, key=None, name=None, value=None)
+
+
+        
+        Fortsett: 
+        Sjekk nøye gjennom parametrene og forklar hvilke som må være fullstendige og hvilke som er partial.
+
+
+
+
 
         Parameters
         ----------

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -478,11 +478,12 @@ class Client:
         namespace : string
             The namespace to search in
         key : string
-            The key to narrow search. Supports "begins with" specification, i.e. will look for matches with "key + wildcard"
+            The key to narrow search. Supports "begins with" specification, 
+            i.e. will look for matches with "key + wildcard"
 
         Returns
         -------
-        dict
+        list
             Metadata entries that matches the search.
 
         """

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -4,6 +4,7 @@ import timeit
 
 import pandas as pd
 import requests
+import warnings
 
 from .rest_api import FilesAPI, MetadataAPI, TimeSeriesAPI
 from .storage import (
@@ -206,28 +207,26 @@ class Client:
     def search(self, namespace, key=None, name=None, value=None):
         """
         Find available series having metadata with given
-        namespace + key* + name + value (optional) combination. Note that if an argument is None, the proceeding ones are also set to None. For example, 
-        (namespace = “hello”, key=None, name=”Rabbit”, value=”Hole”) will have the same effect as (namespace = “hello”, key=None, name=None, value=None)
-
-
-        
-        Fortsett: 
-        Sjekk nøye gjennom parametrene og forklar hvilke som må være fullstendige og hvilke som er partial.
-
-
-
-
+        namespace + key* + name + value (optional) combination. Note that the
+        arguments are hierarchical, starting from the left. If an argument is
+        None, the proceeding ones are also set to None. For example,
+        (namespace = “hello”, key=None, name=”Rabbit”, value=”Hole”)
+        will have the same effect as (namespace = “hello”, key=None, name=None,
+        value=None)
 
         Parameters
         ----------
         namespace : str
-            The namespace to search in
+            Full namespace to search for 
         key : str, optional
-            The key to narrow search. Search is made with wildcard postfix.
+            Key or partial (begins with) key to narrow search.
+            Default (None) will include all.
         name: str, optional
-            name to narrow search further
+            Full name to narrow search further.
+            Default (None) will include all.
         value: str, optional
-            Value to narrow search further. Default (None) will include all.
+            Value or partial (begins or ends with or both) to narrow search further. 
+            Default (None) will include all.
 
         Returns
         -------
@@ -236,6 +235,12 @@ class Client:
             a dict is returned -> ``{TimeSeriesId: metadata}``. Otherwise, a
             plain list with ``TimeSeriesId`` is returned.
         """
+        args_ =  [namespace, key, name, value]
+        none_count = args_.count(None)
+    
+        if args_[-none_count:].count(None) < none_count:
+            warnings.warn('Warning: You have provided argument(s) following a None argument, they are ignored by the search!')
+
         return self._timeseries_api.search(namespace, key, name, value)
 
     def delete(self, series_id):

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -462,9 +462,7 @@ class Client:
         namespace : string
             The namespace to search in
         key : string
-            The key to narrow search
-        conjuctive : bool
-            -
+            The key to narrow search. Supports "begins with" specification, i.e. will look for matches with "key + wildcard"
 
         Returns
         -------
@@ -472,7 +470,7 @@ class Client:
             Metadata entries that matches the search.
 
         """
-        response = self._metadata_api.search(namespace, key, conjunctive)
+        response = self._metadata_api.search(namespace, key)
         return response
 
     def metadata_delete(self, metadata_id):

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -445,35 +445,29 @@ class Client:
 
         return response
 
-    def metadata_browse(self, namespace=None, key=None):
+    def metadata_browse(self, namespace=None):
         """
-        Browse available metadata namespace/key combinations. Note that the 
-        arguments are hierarchical, starting from the left. If "namespace" is 
-        None, "key" is also set to None. For example, 
-        (namespace=None, key="somekey") will have the same effect as 
-        (namespace=None, key=None), i.e. list all available namespaces.
+        List available metadata namespaces and keys. If namespace is None, a list
+        of all available namespaces is returned. If namespace is specified, 
+        a list of all available keys for that namespace is returned. 
 
 
         Parameters
         ----------
         namespace : string
             The namespace to search in
-        key : string
-            the namespace key to narrow search
+
 
         Returns
         -------
-        list or dict
-            The namespaces or keys found. Or if both namespace and key is
-            present, the specific metadata for the namespace/key combination.
+        list
+            The namespaces or keys found. 
         """
 
         if not namespace:
             return self._metadata_api.namespaces()
-        elif not key:
-            return self._metadata_api.keys(namespace)
         else:
-            response = self._metadata_api.get(namespace, key)
+            response = self._metadata_api.get(namespace)
             return response["Value"]
 
     def metadata_search(self, namespace, key):

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -455,7 +455,7 @@ class Client:
             response = self._metadata_api.get(namespace, key)
             return response["Value"]
 
-    def metadata_search(self, namespace, key, conjunctive=True):
+    def metadata_search(self, namespace, key):
         """
         Find metadata entries given namespace/key combination.
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -465,8 +465,7 @@ class Client:
         if not namespace:
             return self._metadata_api.namespaces()
         else:
-            response = self._metadata_api.get(namespace)
-            return response["Value"]
+            return self._metadata_api.keys(namespace)
 
     def metadata_search(self, namespace, key):
         """

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -451,12 +451,10 @@ class Client:
         of all available namespaces is returned. If namespace is specified, 
         a list of all available keys for that namespace is returned. 
 
-
         Parameters
         ----------
         namespace : string
-            The namespace to search in
-
+            The namespace to search in (exact match)
 
         Returns
         -------

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -203,7 +203,7 @@ class Client:
         """
         return self._timeseries_api.info(series_id)
 
-    def search(self, namespace, key, name, value=None):
+    def search(self, namespace, key=None, name=None, value=None):
         """
         Find available series having metadata with given
         namespace + key* + name + value (optional) combination.
@@ -212,9 +212,9 @@ class Client:
         ----------
         namespace : str
             The namespace to search in
-        key : str
+        key : str, optional
             The key to narrow search. Search is made with wildcard postfix.
-        name: str
+        name: str, optional
             name to narrow search further
         value: str, optional
             Value to narrow search further. Default (None) will include all.

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -232,8 +232,9 @@ class Client:
         -------
         dict or list
             Available information about the series. If ``value`` is passed,
-            a dict is returned -> ``{TimeSeriesId: metadata}``. Otherwise, a
-            plain list with ``TimeSeriesId`` is returned.
+            a plain list with ``TimeSeriesId`` is returned. Otherwise, a dict is 
+            returned -> ``{TimeSeriesId: metadata}``.
+
         """
         args_ =  [namespace, key, name, value]
         none_count = args_.count(None)

--- a/datareservoirio/rest_api/metadata.py
+++ b/datareservoirio/rest_api/metadata.py
@@ -167,7 +167,7 @@ class MetadataAPI(BaseAPI):
 
         return sorted(response.json())
 
-    def search(self, namespace, key, conjunctive=True):
+    def search(self, namespace, key):
         """
         Search for metadata entries.
 
@@ -177,18 +177,14 @@ class MetadataAPI(BaseAPI):
             Metadata namespace.
         key : str
             Metadata key.
-        conjunctive : bool
-            Whether to perform a conjunctive search or not. Deafault is True.
-
         Return
         ------
         dict
             response.json()
         """
-        log.debug(f"search with <token>, {namespace} {key} {conjunctive}")
+        log.debug(f"search with <token>, {namespace} {key}")
 
         search_json = _assemble_metadatajson(namespace, key)
-        search_json["Conjunctive"] = conjunctive
 
         uri = self._root + "search"
         response = self._post(uri, json=search_json)

--- a/datareservoirio/rest_api/timeseries.py
+++ b/datareservoirio/rest_api/timeseries.py
@@ -251,7 +251,7 @@ class TimeSeriesAPI(BaseAPI):
         response = self._get(uri, params=params)
         return response.json()
 
-    def search(self, namespace, key, name, value=None):
+    def search(self, namespace, key=None, name=None, value=None):
         """
         Find timeseries with metadata for given namespace/key/name/value
         combination.
@@ -260,9 +260,9 @@ class TimeSeriesAPI(BaseAPI):
         ----------
         namespace : str
             namespace in metadata
-        key : str
+        key : str, optional
             key in metadata
-        name : str
+        name : str, optional
             name in name/value-pair found in metadata value-json
         value : str, optional
             value in name/value-pair found in metadata value-json

--- a/docs/user_guide/browse_search.rst
+++ b/docs/user_guide/browse_search.rst
@@ -22,21 +22,20 @@ You can browse metadata, and search for metadata and series data through
 
 Search for metadata
 -------------------
-You can also search for metadata:
+You can also search for metadata given a namespace and key:
 
 .. code-block:: python
 
-    # Search for *namespace* OR *key*
-    metadata_list = client.metadata_search('foo.bar', 'baz', conjunctive=False)
+    # Search for metadata given *namespace* and *key*
+    metadata_list = client.metadata_search('foo.bar', 'baz')
 
-    # Search for *namespace* AND *key*
-    metadata_list = client.metadata_search('foo.bar', 'baz', conjunctive=True)
 
 .. note::
 
-    The search is "fuzzy" as it looks for matches with
-    "wildcard + search term + wildcard". It is recommended to be as specific as
+    The namespace argument must be a perfect match. They key argument can be "begins with", meaning that 
+    the search looks for matches with "key + wildcard". It is recommended to be as specific as
     possible for best performance.
+
 
 Search for series
 -----------------

--- a/docs/user_guide/browse_search.rst
+++ b/docs/user_guide/browse_search.rst
@@ -4,21 +4,16 @@ Browse and search
 Browse metadata
 ---------------
 You can browse metadata, and search for metadata and series data through
-:py:mod:`datareservoirio`. Lets see how you can browse metadata entries:
+:py:mod:`datareservoirio`. Let's see how you can browse metadata entries:
 
 .. code-block:: python
 
     # List all available namespaces
-    namespaces = client.metadata_browse(namespace=None, key=None)
+    namespaces = client.metadata_browse(namespace=None)
 
     # List all keys under a give namespace
     keys = client.metadata_browse(namespace='foo.bar')
 
-    # List all namespaces that contains a given namespace
-    key_namspaces = client.metadata_browse(key='baz')
-
-    # Get a specific entry (dict)
-    keys = client.metadata_browse(namespace='foo.bar', key='baz')
 
 Search for metadata
 -------------------
@@ -26,7 +21,7 @@ You can also search for metadata given a namespace and key:
 
 .. code-block:: python
 
-    # Search for metadata given *namespace* and *key*
+    # Search for metadata given namespace and key*
     metadata_list = client.metadata_search('foo.bar', 'baz')
 
 
@@ -45,12 +40,46 @@ with it:
 .. code-block:: python
 
     # Get all series that have metadata that satisfies a search:
-    # namespace + key* + name + value (optional)
+    # namespace + key* (optional) + name (optional) + *value* (optional)
 
     series_ids_list = client.search('foo.bar', 'baz', 'sensor_vendor')
 
     series_ids_dict = client.search('foo.bar', 'baz', 'sensor_vendor',
-                                    value='Sensor Corp')
+                                    'Sensor Corp')
+
+
+The search function has one required argument (namespace), the rest are optional:
+
+.. list-table::
+   :widths: 25 75
+
+   * - namespace
+     - required, must be exact match   
+   * - key
+     - optional, defaults to None. Can be "begins with"
+   * - name
+     - optional, defaults to None. Must be exact match
+   * - value
+     - optional, defaults to None. Can be "begins with" or "ends with" or a combination. 
+
+
+
+.. note::
+    
+    The arguments in client.search are hierarchical and starts from the left. If one argument is set to None, 
+    all processing arguments will be treated as none. For example, client.search('foo.bar', None, 'sensor_vendor')
+    will return the same result as client.search('foo.bar')
+
+
+Series information
+------------------
+The client.info() method returns a dict containing all available metadata for a given time series:
+
+.. code-block:: python
+
+    ts_id = '0f10c985-ad2c-409f-aa5d-e592b11b8526'
+    info = client.info(ts_id)
+
 
 
 .. _DataReservoir.io: https://www.datareservoir.io/

--- a/docs/user_guide/browse_search.rst
+++ b/docs/user_guide/browse_search.rst
@@ -34,7 +34,7 @@ You can also search for metadata given a namespace and key:
 
 Search for series
 -----------------
-In addition, you can search directly for series based on metadata associated
+In addition, you can search directly for time series based on metadata associated
 with it:
 
 .. code-block:: python
@@ -67,7 +67,7 @@ The search function has one required argument (namespace), the rest are optional
 .. note::
     
     The arguments in client.search are hierarchical and starts from the left. If one argument is set to None, 
-    all processing arguments will be treated as none. For example, client.search('foo.bar', None, 'sensor_vendor')
+    all proceeding arguments will be treated as none. For example, client.search('foo.bar', None, 'sensor_vendor')
     will return the same result as client.search('foo.bar')
 
 

--- a/docs/user_guide/browse_search.rst
+++ b/docs/user_guide/browse_search.rst
@@ -32,7 +32,7 @@ You can also search for metadata given a namespace and key:
 
 .. note::
 
-    The namespace argument must be a perfect match. They key argument can be "begins with", meaning that 
+    The namespace argument must be an exact match. They key argument can be "begins with", meaning that 
     the search looks for matches with "key + wildcard". It is recommended to be as specific as
     possible for best performance.
 

--- a/docs/user_guide/browse_search.rst
+++ b/docs/user_guide/browse_search.rst
@@ -73,7 +73,7 @@ The search function has one required argument (namespace), the rest are optional
 
 Series information
 ------------------
-The client.info() method returns a dict containing all available metadata for a given time series:
+The client.info() method returns a dict containing all available metadata for a given time series id:
 
 .. code-block:: python
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pandas as pd
 import requests
+import pytest
+
 
 import datareservoirio
 from datareservoirio import Client
@@ -413,6 +415,10 @@ class Test_Client(unittest.TestCase):
         self.client._timeseries_api.search.assert_called_once_with(
             "test_namespace", "test_key", "test_name", 123
         )
+
+    def test_search_None(self):
+        with pytest.warns():
+            self.client.search("test_namespace", None, "test_name", 123)
 
     def test_metadata_get_with_id(self):
         self.client._metadata_api.get_by_id.return_value = {"Id": "123abc"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -458,27 +458,10 @@ class Test_Client(unittest.TestCase):
         self.client.metadata_browse(namespace="test_namespace")
         self.client._metadata_api.keys.assert_called_once_with("test_namespace")
 
-    def test_metadata_browse_names(self):
-        self.client._metadata_api.get.return_value = {"Value": "{}"}
-
-        self.client.metadata_browse(namespace="test_namespace", key="test_key")
-        self.client._metadata_api.get.assert_called_once_with(
-            "test_namespace", "test_key"
-        )
-
-    def test_metadata_search_conjunctive_true(self):
+    def test_metadata_search(self):
         self.client.metadata_search(namespace="test_namespace", key="test_key")
         self.client._metadata_api.search.assert_called_once_with(
-            "test_namespace", "test_key", True
-        )
-
-    def test_metadata_search_conjunctive_false(self):
-        self.client.metadata_search(
-            namespace="test_namespace", key="test_key", conjunctive=False
-        )
-        self.client._metadata_api.search.assert_called_once_with(
-            "test_namespace", "test_key", False
-        )
+            "test_namespace", "test_key")
 
     def test_metadata_delete(self):
         self.client.metadata_delete("id123")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,9 +3,8 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
-import requests
 import pytest
-
+import requests
 
 import datareservoirio
 from datareservoirio import Client
@@ -461,7 +460,8 @@ class Test_Client(unittest.TestCase):
     def test_metadata_search(self):
         self.client.metadata_search(namespace="test_namespace", key="test_key")
         self.client._metadata_api.search.assert_called_once_with(
-            "test_namespace", "test_key")
+            "test_namespace", "test_key"
+        )
 
     def test_metadata_delete(self):
         self.client.metadata_delete("id123")

--- a/tests/test_rest_api/test_metadata.py
+++ b/tests/test_rest_api/test_metadata.py
@@ -115,12 +115,11 @@ class Test_MetadataAPI(unittest.TestCase):
         search_json = {
             "Namespace": "hello",
             "Key": "world",
-            "Value": {},
-            "Conjunctive": False,
+            "Value": {}
         }
         mock_post = self.api._session.post
 
-        self.api.search("hello", "world", conjunctive=False)
+        self.api.search("hello", "world")
 
         expected_uri = "https://root/metadata/search"
 

--- a/tests/test_rest_api/test_metadata.py
+++ b/tests/test_rest_api/test_metadata.py
@@ -112,11 +112,7 @@ class Test_MetadataAPI(unittest.TestCase):
         mock_post.assert_called_with(expected_uri, **self.api._defaults)
 
     def test_search(self):
-        search_json = {
-            "Namespace": "hello",
-            "Key": "world",
-            "Value": {}
-        }
+        search_json = {"Namespace": "hello", "Key": "world", "Value": {}}
         mock_post = self.api._session.post
 
         self.api.search("hello", "world")


### PR DESCRIPTION
### This PR is related to user story DST-372

## Description
- Updated metadata_browse, metadata_search, search methods to align better with what is actuallly available in the API. 
- Exception: metadata_browse has limited functionality, can only list all namespaces or all keys for a namespace  as per PO request. 
- Expanded and updated userguide to reflect changes in code, included a new example for .info method. 


## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

