### PR TITLE
Return empty Series if no data is available in the datareservoirio

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -291,14 +291,18 @@ class Client:
         time_start = timeit.default_timer()
 
         log.debug("Getting series range")
-        series = (
-            self._storage.get(series_id, start, end)
-            .set_index("index")
-            .squeeze("columns")
-            .loc[start:end]
-            .copy(deep=True)
-        )
-        series.index.name = None
+        df = self._storage.get(series_id, start, end)
+        if df.empty:
+            series = pd.Series(dtype="object")
+        else:
+            series = (
+                df
+                .set_index("index")
+                .squeeze("columns")
+                .loc[start:end]
+                .copy(deep=True)
+            )
+            series.index.name = None
 
         if series.empty and raise_empty:  # may become empty after slicing
             raise ValueError("can't find data in the given interval")

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -300,19 +300,6 @@ class Client:
         )
         series.index.name = None
 
-        # df = self._storage.get(series_id, start, end)
-        # if df.empty:
-        #     series = pd.Series(dtype="object")
-        # else:
-        #     series = (
-        #         df
-        #         .set_index("index")
-        #         .squeeze("columns")
-        #         .loc[start:end]
-        #         .copy(deep=True)
-        #     )
-        #     series.index.name = None
-
         if series.empty and raise_empty:  # may become empty after slicing
             raise ValueError("can't find data in the given interval")
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -291,18 +291,27 @@ class Client:
         time_start = timeit.default_timer()
 
         log.debug("Getting series range")
-        df = self._storage.get(series_id, start, end)
-        if df.empty:
-            series = pd.Series(dtype="object")
-        else:
-            series = (
-                df
-                .set_index("index")
-                .squeeze("columns")
-                .loc[start:end]
-                .copy(deep=True)
-            )
-            series.index.name = None
+        series = (
+            self._storage.get(series_id, start, end)
+            .set_index("index")
+            .squeeze("columns")
+            .loc[start:end]
+            .copy(deep=True)
+        )
+        series.index.name = None
+
+        # df = self._storage.get(series_id, start, end)
+        # if df.empty:
+        #     series = pd.Series(dtype="object")
+        # else:
+        #     series = (
+        #         df
+        #         .set_index("index")
+        #         .squeeze("columns")
+        #         .loc[start:end]
+        #         .copy(deep=True)
+        #     )
+        #     series.index.name = None
 
         if series.empty and raise_empty:  # may become empty after slicing
             raise ValueError("can't find data in the given interval")

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -118,13 +118,18 @@ class BaseDownloader:
         for fd in filedatas:
             df = self._combine_first(fd, df)
 
-        if not df.empty:
-            df.reset_index(inplace=True)  # Temporary hotfix while waiting for refactor
+        df.reset_index(inplace=True)  # Temporary hotfix while waiting for refactor
         return df
 
     def _download_chunks_as_dataframe(self, chunks):
         if not chunks:
-            return pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
+            df_chunks = pd.DataFrame(columns=("index", "values")).astype(
+                {"index": "int64"}
+            )
+            df_chunks.set_index(
+                "index", inplace=True
+            )  # Temporary hotfix while waiting for refactor
+            return df_chunks
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             filechunks = executor.map(self._download_verified_chunk, chunks)

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -91,11 +91,6 @@ class Storage:
         log.debug("getting day file inventory")
         response = self._timeseries_api.download_days(timeseries_id, start, end)
         df = self._downloader.get(response)
-        if df.empty:
-            return (
-                pd.DataFrame(columns=("index", "value"))
-                .astype({"index": "int64", "value": "string"})
-            )
         return df
 
 
@@ -118,7 +113,7 @@ class BaseDownloader:
         try:
             df = next(filedatas)
         except StopIteration:
-            return pd.DataFrame()
+            return pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
 
         for fd in filedatas:
             df = self._combine_first(fd, df)
@@ -128,7 +123,7 @@ class BaseDownloader:
 
     def _download_chunks_as_dataframe(self, chunks):
         if not chunks:
-            return pd.DataFrame()
+            return pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             filechunks = executor.map(self._download_verified_chunk, chunks)

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -118,7 +118,8 @@ class BaseDownloader:
         for fd in filedatas:
             df = self._combine_first(fd, df)
 
-        df.reset_index(inplace=True)  # Temporary hotfix while waiting for refactor
+        if not df.empty:
+            df.reset_index(inplace=True)  # Temporary hotfix while waiting for refactor
         return df
 
     def _download_chunks_as_dataframe(self, chunks):

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -91,6 +91,11 @@ class Storage:
         log.debug("getting day file inventory")
         response = self._timeseries_api.download_days(timeseries_id, start, end)
         df = self._downloader.get(response)
+        if df.empty:
+            return (
+                pd.DataFrame(columns=("index", "value"))
+                .astype({"index": "int64", "value": "string"})
+            )
         return df
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -410,6 +410,22 @@ class Test_Client(unittest.TestCase):
 
         pd.testing.assert_series_equal(response, response_expected, check_dtype=False)
 
+    def test_get_empty(self):
+        self._storage.get.return_value = pd.DataFrame(
+            columns=("index", "values")
+        ).astype({"index": "int64"})
+        response_expected = pd.Series(name="values", dtype="object")
+        response_expected.index = pd.to_datetime(response_expected.index, utc=True)
+
+        response = self.client.get(self.timeseries_id)
+
+        self.client._storage.get.assert_called_once_with(
+            self.timeseries_id,
+            datareservoirio.client._START_DEFAULT,
+            datareservoirio.client._END_DEFAULT - 1,
+        )
+        pd.testing.assert_series_equal(response, response_expected)
+
     def test_get_with_raise_empty_throws(self):
         index = np.array([6, 7, 8, 9, 10])
         values = np.array([6.0, 7.0, 8.0, 9.0, 10.0])

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -332,6 +332,19 @@ class Test_BaseDownloader(unittest.TestCase):
 
         pd.testing.assert_frame_equal(df_expected, df_out)
 
+    def test__download_chunks_as_dataframe_no_chunks(self):
+        mock_backend = MagicMock()
+
+        df_expected = pd.DataFrame(columns=("index", "values")).astype(
+            {"index": "int64"}
+        )
+
+        base_downloader = BaseDownloader(mock_backend)
+        df_out = base_downloader._download_chunks_as_dataframe([])
+
+        mock_backend.assert_not_called()
+        pd.testing.assert_frame_equal(df_expected, df_out)
+
 
 class Test_FileCachceDownload(unittest.TestCase):
     def setUp(self):

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -234,29 +234,7 @@ class Test_BaseDownloader(unittest.TestCase):
         mock_backend = MagicMock()
         base_downloader = BaseDownloader(mock_backend)
 
-        response = {"Files": [{"Chunks": []}]}
-
-        with patch.object(
-            base_downloader, "_download_chunks_as_dataframe"
-        ) as mock_download:
-            mock_download.return_value = pd.DataFrame(
-                columns=("index", "values")
-            ).astype({"index": "int64"})
-
-            df_out = base_downloader.get(response)
-
-        df_expected = pd.DataFrame(
-            pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
-        )
-
-        pd.testing.assert_frame_equal(df_expected, df_out)
-        mock_download.assert_called_once_with([])
-
-    def test_get_empty2(self):
-        mock_backend = MagicMock()
-        base_downloader = BaseDownloader(mock_backend)
-
-        response = {"Files": [{"Chunks": []}]}
+        response = {"Files": []}
 
         df_out = base_downloader.get(response)
 

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -252,6 +252,20 @@ class Test_BaseDownloader(unittest.TestCase):
         pd.testing.assert_frame_equal(df_expected, df_out)
         mock_download.assert_called_once_with([])
 
+    def test_get_empty2(self):
+        mock_backend = MagicMock()
+        base_downloader = BaseDownloader(mock_backend)
+
+        response = {"Files": [{"Chunks": []}]}
+
+        df_out = base_downloader.get(response)
+
+        df_expected = pd.DataFrame(
+            pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
+        )
+
+        pd.testing.assert_frame_equal(df_expected, df_out)
+
     def test__combine_first_no_overlap(self):
         df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
         df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[6, 7, 8, 9])

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -230,6 +230,28 @@ class Test_BaseDownloader(unittest.TestCase):
 
         pd.testing.assert_frame_equal(df_expected, df_out)
 
+    def test_get_empty(self):
+        mock_backend = MagicMock()
+        base_downloader = BaseDownloader(mock_backend)
+
+        response = {"Files": [{"Chunks": []}]}
+
+        with patch.object(
+            base_downloader, "_download_chunks_as_dataframe"
+        ) as mock_download:
+            mock_download.return_value = pd.DataFrame(
+                columns=("index", "values")
+            ).astype({"index": "int64"})
+
+            df_out = base_downloader.get(response)
+
+        df_expected = pd.DataFrame(
+            pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
+        )
+
+        pd.testing.assert_frame_equal(df_expected, df_out)
+        mock_download.assert_called_once_with([])
+
     def test__combine_first_no_overlap(self):
         df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
         df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[6, 7, 8, 9])

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -331,8 +331,10 @@ class Test_BaseDownloader(unittest.TestCase):
         base_downloader = BaseDownloader(mock_backend)
         df_out = base_downloader._download_chunks_as_dataframe([])
 
-        df_expected = pd.DataFrame(columns=("index", "values")).astype(
-            {"index": "int64"}
+        df_expected = (
+            pd.DataFrame(columns=("index", "values"))
+            .astype({"index": "int64"})
+            .set_index("index")
         )
 
         mock_backend.assert_not_called()

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -242,6 +242,7 @@ class Test_BaseDownloader(unittest.TestCase):
             pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
         )
 
+        mock_backend.assert_not_called()
         pd.testing.assert_frame_equal(df_expected, df_out)
 
     def test__combine_first_no_overlap(self):

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -335,12 +335,12 @@ class Test_BaseDownloader(unittest.TestCase):
     def test__download_chunks_as_dataframe_no_chunks(self):
         mock_backend = MagicMock()
 
+        base_downloader = BaseDownloader(mock_backend)
+        df_out = base_downloader._download_chunks_as_dataframe([])
+
         df_expected = pd.DataFrame(columns=("index", "values")).astype(
             {"index": "int64"}
         )
-
-        base_downloader = BaseDownloader(mock_backend)
-        df_out = base_downloader._download_chunks_as_dataframe([])
 
         mock_backend.assert_not_called()
         pd.testing.assert_frame_equal(df_expected, df_out)


### PR DESCRIPTION
### This PR is related to user story DST-384

## Description
Fixed bug when there is no data in drio. Return empty Series.

See user story:
https://4insight.atlassian.net/jira/software/c/projects/DST/boards/12?modal=detail&selectedIssue=DST-384

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

