### PR TITLE
Small cleanups: typos + refactor code to remove enter and exit methods

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -68,12 +68,6 @@ class Client:
 
         self._storage = Storage(self._timeseries_api, downloader, self._auth_session)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        return self
-
     def ping(self):
         """
         Test that you have a working connection to DataReservoir.io.

--- a/datareservoirio/rest_api/files.py
+++ b/datareservoirio/rest_api/files.py
@@ -32,7 +32,7 @@ class FilesAPI(BaseAPI):
 
         log.debug("upload with <token>")
 
-        uri = self._api_base_url + "Files/upload"
+        uri = self._api_base_url + "files/upload"
         response = self._post(uri)
 
         if log.isEnabledFor(logging.DEBUG):
@@ -57,7 +57,7 @@ class FilesAPI(BaseAPI):
         """
         log.debug(f"commit with <token>, {file_id}")
 
-        uri = self._api_base_url + "Files/commit"
+        uri = self._api_base_url + "files/commit"
         body = {"FileId": file_id}
         response = self._post(uri, data=body)
         return response.status_code

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,7 +151,6 @@ class Test_Client(unittest.TestCase):
     def test_init_with_invalid_cache_format_raises_exception(self):
         with self.assertRaises(ValueError):
             Client(self.auth, cache=True, cache_opt={"format": "bogusformat"})
-            # pass
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_cache_root(self, mock_cache):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -112,44 +112,46 @@ class Test_Client(unittest.TestCase):
 
     @patch("datareservoirio.client.DirectDownload")
     def test_init_with_cache_disabled(self, mock_dl):
-        with Client(self.auth, cache=False):
-            assert mock_dl.call_count == 1
+        Client(self.auth, cache=False)
+        assert mock_dl.call_count == 1
+        # close client?
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_defaults_cache_is_enabled_and_format_parquet(self, mock_cache):
-        with Client(self.auth):
-            kwargs = mock_cache.call_args[1]
-            self.assertIn("format_", kwargs)
-            self.assertEqual(kwargs["format_"], "parquet")
-            cache_defaults = Client.CACHE_DEFAULT.copy()
-            cache_defaults["format_"] = cache_defaults.pop("format")
-            mock_cache.assert_called_once_with(**cache_defaults)
+        Client(self.auth)
+        kwargs = mock_cache.call_args[1]
+        self.assertIn("format_", kwargs)
+        self.assertEqual(kwargs["format_"], "parquet")
+        cache_defaults = Client.CACHE_DEFAULT.copy()
+        cache_defaults["format_"] = cache_defaults.pop("format")
+        mock_cache.assert_called_once_with(**cache_defaults)
+        # close client?
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_cache_enabled(self, mock_cache):
-        with Client(self.auth, cache=True):
-            cache_defaults = Client.CACHE_DEFAULT.copy()
-            cache_defaults["format_"] = cache_defaults.pop("format")
-            mock_cache.assert_called_once_with(**cache_defaults)
+        Client(self.auth, cache=True)
+        cache_defaults = Client.CACHE_DEFAULT.copy()
+        cache_defaults["format_"] = cache_defaults.pop("format")
+        mock_cache.assert_called_once_with(**cache_defaults)
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_cache_format_csv(self, mock_cache):
-        with Client(self.auth, cache=True, cache_opt={"format": "csv"}):
-            kwargs = mock_cache.call_args[1]
-            self.assertIn("format_", kwargs)
-            self.assertEqual(kwargs["format_"], "csv")
+        Client(self.auth, cache=True, cache_opt={"format": "csv"})
+        kwargs = mock_cache.call_args[1]
+        self.assertIn("format_", kwargs)
+        self.assertEqual(kwargs["format_"], "csv")
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_cache_format_parquet(self, mock_cache):
-        with Client(self.auth, cache={"format": "parquet"}):
-            kwargs = mock_cache.call_args[1]
-            self.assertIn("format_", kwargs)
-            self.assertEqual(kwargs["format_"], "parquet")
+        Client(self.auth, cache={"format": "parquet"})
+        kwargs = mock_cache.call_args[1]
+        self.assertIn("format_", kwargs)
+        self.assertEqual(kwargs["format_"], "parquet")
 
     def test_init_with_invalid_cache_format_raises_exception(self):
         with self.assertRaises(ValueError):
-            with Client(self.auth, cache=True, cache_opt={"format": "bogusformat"}):
-                pass
+            Client(self.auth, cache=True, cache_opt={"format": "bogusformat"})
+                #pass
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_cache_root(self, mock_cache):
@@ -157,8 +159,8 @@ class Test_Client(unittest.TestCase):
         cache_defaults["format_"] = cache_defaults.pop("format")
         cache_defaults["cache_root"] = "a:\\diskett"
 
-        with Client(self.auth, cache=True, cache_opt={"cache_root": "a:\\diskett"}):
-            mock_cache.assert_called_once_with(**cache_defaults)
+        Client(self.auth, cache=True, cache_opt={"cache_root": "a:\\diskett"})
+        mock_cache.assert_called_once_with(**cache_defaults)
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_cache_max_size(self, mock_cache):
@@ -166,8 +168,9 @@ class Test_Client(unittest.TestCase):
         cache_defaults["format_"] = cache_defaults.pop("format")
         cache_defaults["max_size"] = 10
 
-        with Client(self.auth, cache=True, cache_opt={"max_size": 10}):
-            mock_cache.assert_called_once_with(**cache_defaults)
+        Client(self.auth, cache=True, cache_opt={"max_size": 10})
+        mock_cache.assert_called_once_with(**cache_defaults)
+
 
     def test_ping_request(self):
         self.client._files_api.ping.return_value = {"status": "pong"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,7 +151,7 @@ class Test_Client(unittest.TestCase):
     def test_init_with_invalid_cache_format_raises_exception(self):
         with self.assertRaises(ValueError):
             Client(self.auth, cache=True, cache_opt={"format": "bogusformat"})
-                #pass
+            # pass
 
     @patch("datareservoirio.client.FileCacheDownload")
     def test_init_with_cache_root(self, mock_cache):
@@ -170,7 +170,6 @@ class Test_Client(unittest.TestCase):
 
         Client(self.auth, cache=True, cache_opt={"max_size": 10})
         mock_cache.assert_called_once_with(**cache_defaults)
-
 
     def test_ping_request(self):
         self.client._files_api.ping.return_value = {"status": "pong"}

--- a/tests/test_rest_api/test_files.py
+++ b/tests/test_rest_api/test_files.py
@@ -51,7 +51,7 @@ class Test_FilesAPI(unittest.TestCase):
         result = self.api.upload()
 
         mock_post.assert_called_once_with(
-            "https://reservoir-api-qa.4subsea.net/api/Files/upload",
+            "https://reservoir-api-qa.4subsea.net/api/files/upload",
             **self.api._defaults
         )
 
@@ -64,7 +64,7 @@ class Test_FilesAPI(unittest.TestCase):
         self.api.commit("fileid")
 
         mock_post.assert_called_with(
-            "https://reservoir-api-qa.4subsea.net/api/Files/commit",
+            "https://reservoir-api-qa.4subsea.net/api/files/commit",
             data={"FileId": "fileid"},
             **self.api._defaults
         )


### PR DESCRIPTION
### This PR is related to user story DST-NA

## Description
- Changed "Files" to "files" in  some urls to agree with url in swagger and rest of code
- removed __enter__ and __exit__ from Client
- modified tests that used Client as context manager 


## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

