### PR TITLE
Remove support for cache format selection, and simplify storage related code

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -52,7 +52,7 @@ class Client:
                 pass
             else:
                 warnings.warn(
-                    "Support for choosing cache format depraceted. 'format' will be ignored.",
+                    "Support for choosing cache format deprecated. 'format' will be ignored.",
                     FutureWarning,
                 )
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -46,32 +46,25 @@ class Client:
         self._timeseries_api = TimeSeriesAPI(self._auth_session, cache=cache)
         self._files_api = FilesAPI(self._auth_session)
         self._metadata_api = MetadataAPI(self._auth_session)
-        # self._enable_cache = cache
 
-        # # Emit deprecation warning if "format" is provided
-        # if self._enable_cache:
-        #     cache_default = self.CACHE_DEFAULT.copy()
-        #     if set(cache_default.keys()).issuperset(cache_opt):
-        #         cache_default.update(cache_opt)
-        #         self._cache_opt = cache_default
-        #         self._cache_format = self._cache_opt.pop("format")
-        #     else:
-        #         raise ValueError("cache_opt contains unknown keywords.")
+        if cache:
+            cache_opt.update(
+                (key, self.CACHE_DEFAULT[key])
+                for key in set(self.CACHE_DEFAULT.keys()).difference(cache_opt)
+                )
 
-        # if self._enable_cache:
-        #     raise NotImplementedError("Temporarily disabled")
-        #     download_backend = FileCacheDownload(
-        #         format_=self._cache_format, **self._cache_opt
-        #     )
-        # else:
-        #     download_backend = None
-
-        # downloader = BaseDownloader(download_backend)
+            if "format" in cache_opt:
+                warnings.warn(
+                    "Support for choosing cache format depraceted."
+                    "'format' will be ignored.",
+                    DeprecationWarning
+                    )
+                del cache_opt["format"]
 
         self._storage = Storage(
             self._timeseries_api,
             self._auth_session,
-            cache,
+            cache=cache,
             cache_opt=cache_opt
             )
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -37,6 +37,7 @@ class Client:
         specific defaults.
 
     """
+
     def __init__(self, auth, cache=True, cache_opt=None):
         self._auth_session = auth
         self._timeseries_api = TimeSeriesAPI(self._auth_session, cache=cache)
@@ -52,15 +53,12 @@ class Client:
             else:
                 warnings.warn(
                     "Support for choosing cache format depraceted. 'format' will be ignored.",
-                    FutureWarning
-                    )
+                    FutureWarning,
+                )
 
         self._storage = Storage(
-            self._timeseries_api,
-            self._auth_session,
-            cache=cache,
-            cache_opt=cache_opt
-            )
+            self._timeseries_api, self._auth_session, cache=cache, cache_opt=cache_opt
+        )
 
     def ping(self):
         """

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -43,6 +43,7 @@ class Client:
         self._files_api = FilesAPI(self._auth_session)
         self._metadata_api = MetadataAPI(self._auth_session)
 
+        # TODO: Remove after 2023-08-15
         if cache:
             try:
                 del cache_opt["format"]

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -9,7 +9,7 @@ import requests
 
 from .globalsettings import environment
 from .rest_api import FilesAPI, MetadataAPI, TimeSeriesAPI
-from .storage import BaseDownloader, FileCacheDownload, Storage
+from .storage import Storage
 
 log = logging.getLogger(__name__)
 
@@ -46,20 +46,20 @@ class Client:
         self._timeseries_api = TimeSeriesAPI(self._auth_session, cache=cache)
         self._files_api = FilesAPI(self._auth_session)
         self._metadata_api = MetadataAPI(self._auth_session)
-        self._enable_cache = cache
+        # self._enable_cache = cache
 
-        # Emit deprecation warning if "format" is provided
-        if self._enable_cache:
-            cache_default = self.CACHE_DEFAULT.copy()
-            if set(cache_default.keys()).issuperset(cache_opt):
-                cache_default.update(cache_opt)
-                self._cache_opt = cache_default
-                self._cache_format = self._cache_opt.pop("format")
-            else:
-                raise ValueError("cache_opt contains unknown keywords.")
+        # # Emit deprecation warning if "format" is provided
+        # if self._enable_cache:
+        #     cache_default = self.CACHE_DEFAULT.copy()
+        #     if set(cache_default.keys()).issuperset(cache_opt):
+        #         cache_default.update(cache_opt)
+        #         self._cache_opt = cache_default
+        #         self._cache_format = self._cache_opt.pop("format")
+        #     else:
+        #         raise ValueError("cache_opt contains unknown keywords.")
 
-        if self._enable_cache:
-            raise NotImplementedError("Temporarily disabled")
+        # if self._enable_cache:
+        #     raise NotImplementedError("Temporarily disabled")
         #     download_backend = FileCacheDownload(
         #         format_=self._cache_format, **self._cache_opt
         #     )
@@ -68,7 +68,12 @@ class Client:
 
         # downloader = BaseDownloader(download_backend)
 
-        self._storage = Storage(self._timeseries_api, self._auth_session)  # (cache_opts)
+        self._storage = Storage(
+            self._timeseries_api,
+            self._auth_session,
+            cache,
+            cache_opt=cache_opt
+            )
 
     def __enter__(self):
         return self

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -32,34 +32,43 @@ class Client:
         Enable caching (default).
     cache_opt : dict, optional
         Configuration object for controlling the series cache.
-        'format': 'parquet' or 'csv'. Default is 'parquet'.
         'max_size': max size of cache in megabytes. Default is 1024 MB.
         'cache_root': cache storage location. See documentation for platform
         specific defaults.
 
     """
     # Remove support for format, use only parquet.
-    CACHE_DEFAULT = {"format": "parquet", "max_size": 1024, "cache_root": None}
+    # CACHE_DEFAULT = {"format": "parquet", "max_size": 1024, "cache_root": None}
 
-    def __init__(self, auth, cache=True, cache_opt=CACHE_DEFAULT):
+    def __init__(self, auth, cache=True, cache_opt=None):
         self._auth_session = auth
         self._timeseries_api = TimeSeriesAPI(self._auth_session, cache=cache)
         self._files_api = FilesAPI(self._auth_session)
         self._metadata_api = MetadataAPI(self._auth_session)
 
         if cache:
-            cache_opt.update(
-                (key, self.CACHE_DEFAULT[key])
-                for key in set(self.CACHE_DEFAULT.keys()).difference(cache_opt)
-                )
-
-            if "format" in cache_opt:
+            try:
+                del cache_opt["format"]
+            except (TypeError, KeyError):
+                pass
+            else:
                 warnings.warn(
-                    "Support for choosing cache format depraceted."
-                    "'format' will be ignored.",
+                    "Support for choosing cache format depraceted. 'format' will be ignored.",
                     DeprecationWarning
                     )
-                del cache_opt["format"]
+
+            # # cache_opt.update(
+            # #     (key, self.CACHE_DEFAULT[key])
+            # #     for key in set(self.CACHE_DEFAULT.keys()).difference(cache_opt)
+            # #     )
+
+            # if isinstance(cache_opt, dict) and "format" in cache_opt:
+            #     warnings.warn(
+            #         "Support for choosing cache format depraceted."
+            #         "'format' will be ignored.",
+            #         DeprecationWarning
+            #         )
+            #     del cache_opt["format"]
 
         self._storage = Storage(
             self._timeseries_api,

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -37,9 +37,6 @@ class Client:
         specific defaults.
 
     """
-    # Remove support for format, use only parquet.
-    # CACHE_DEFAULT = {"format": "parquet", "max_size": 1024, "cache_root": None}
-
     def __init__(self, auth, cache=True, cache_opt=None):
         self._auth_session = auth
         self._timeseries_api = TimeSeriesAPI(self._auth_session, cache=cache)
@@ -54,21 +51,8 @@ class Client:
             else:
                 warnings.warn(
                     "Support for choosing cache format depraceted. 'format' will be ignored.",
-                    DeprecationWarning
+                    FutureWarning
                     )
-
-            # # cache_opt.update(
-            # #     (key, self.CACHE_DEFAULT[key])
-            # #     for key in set(self.CACHE_DEFAULT.keys()).difference(cache_opt)
-            # #     )
-
-            # if isinstance(cache_opt, dict) and "format" in cache_opt:
-            #     warnings.warn(
-            #         "Support for choosing cache format depraceted."
-            #         "'format' will be ignored.",
-            #         DeprecationWarning
-            #         )
-            #     del cache_opt["format"]
 
         self._storage = Storage(
             self._timeseries_api,

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -9,7 +9,7 @@ import requests
 
 from .globalsettings import environment
 from .rest_api import FilesAPI, MetadataAPI, TimeSeriesAPI
-from .storage import BaseDownloader, DirectDownload, FileCacheDownload, Storage
+from .storage import BaseDownloader, FileCacheDownload, Storage
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class Client:
         specific defaults.
 
     """
-
+    # Remove support for format, use only parquet.
     CACHE_DEFAULT = {"format": "parquet", "max_size": 1024, "cache_root": None}
 
     def __init__(self, auth, cache=True, cache_opt=CACHE_DEFAULT):
@@ -48,6 +48,7 @@ class Client:
         self._metadata_api = MetadataAPI(self._auth_session)
         self._enable_cache = cache
 
+        # Emit deprecation warning if "format" is provided
         if self._enable_cache:
             cache_default = self.CACHE_DEFAULT.copy()
             if set(cache_default.keys()).issuperset(cache_opt):
@@ -58,15 +59,16 @@ class Client:
                 raise ValueError("cache_opt contains unknown keywords.")
 
         if self._enable_cache:
-            download_backend = FileCacheDownload(
-                format_=self._cache_format, **self._cache_opt
-            )
-        else:
-            download_backend = DirectDownload()
+            raise NotImplementedError("Temporarily disabled")
+        #     download_backend = FileCacheDownload(
+        #         format_=self._cache_format, **self._cache_opt
+        #     )
+        # else:
+        #     download_backend = None
 
-        downloader = BaseDownloader(download_backend)
+        # downloader = BaseDownloader(download_backend)
 
-        self._storage = Storage(self._timeseries_api, downloader, self._auth_session)
+        self._storage = Storage(self._timeseries_api, self._auth_session)  # (cache_opts)
 
     def __enter__(self):
         return self

--- a/datareservoirio/storage/__init__.py
+++ b/datareservoirio/storage/__init__.py
@@ -1,1 +1,1 @@
-from .storage import BaseDownloader, DirectDownload, FileCacheDownload, Storage
+from .storage import BaseDownloader, FileCacheDownload, Storage

--- a/datareservoirio/storage/__init__.py
+++ b/datareservoirio/storage/__init__.py
@@ -1,1 +1,1 @@
-from .storage import BaseDownloader, StorageCache, Storage
+from .storage import BaseDownloader, Storage, StorageCache

--- a/datareservoirio/storage/__init__.py
+++ b/datareservoirio/storage/__init__.py
@@ -1,1 +1,1 @@
-from .storage import BaseDownloader, FileCacheDownload, Storage
+from .storage import BaseDownloader, StorageCache, Storage

--- a/datareservoirio/storage/cache_engine.py
+++ b/datareservoirio/storage/cache_engine.py
@@ -18,6 +18,7 @@ class CacheIO:
     Basic cache related disk operations.
 
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/datareservoirio/storage/cache_engine.py
+++ b/datareservoirio/storage/cache_engine.py
@@ -1,8 +1,6 @@
-import codecs
 import io
 import logging
 import os
-from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import OrderedDict
 
 import pandas as pd
@@ -15,77 +13,12 @@ log = logging.getLogger(__name__)
 _BYTES_PER_ROW = 128 // 8
 
 
-class GenericFormat(metaclass=ABCMeta):
-    """
-    Abstract class for file format classes.
-    """
-
-    @abstractproperty
-    def file_extension(self):
-        pass
-
-    @abstractmethod
-    def serialize(self, dataframe, stream):
-        pass
-
-    @abstractmethod
-    def deserialize(self, stream):
-        pass
-
-
-class CsvFormat(GenericFormat):
-    """Serialize dataframe to/from the csv format."""
-
-    def __init__(self):
-        self._reader_factory = codecs.getreader("utf-8")
-        self._writer_factory = codecs.getwriter("utf-8")
-
-    @property
-    def file_extension(self):
-        return "csv"
-
-    def serialize(self, dataframe, stream):
-        with self._writer_factory(stream) as sw:
-            dataframe.to_csv(sw, header=True, encoding="ascii")
-
-    def deserialize(self, stream):
-        with self._reader_factory(stream) as sr:
-            return pd.read_csv(sr, index_col=0, encoding="ascii")
-
-
-class ParquetFormat(GenericFormat):
-    """Serialize dataframe to/from the parquet format."""
-
-    @property
-    def file_extension(self):
-        return "parquet"
-
-    def serialize(self, dataframe, stream):
-        dataframe.to_parquet(stream)
-
-    def deserialize(self, stream):
-        return pd.read_parquet(stream)
-
-
 class CacheIO:
     """
     Basic cache related disk operations.
 
-    Parameter
-    ---------
-    format : str
-        Which format to use when storing files in the cache. Accepts `parquet`
-        (recommended) for Parquet, and `csv` for CSV.
-
     """
-
-    def __init__(self, format_, *args, **kwargs):
-        if format_ == "parquet":
-            self._io_backend = ParquetFormat()
-        elif format_ == "csv":
-            self._io_backend = CsvFormat()
-        else:
-            raise ValueError("Unreckognized format: {}".format(format))
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def _write(self, data, filepath):
@@ -93,7 +26,7 @@ class CacheIO:
         with io.open(pre_filepath, "wb") as file_:
             try:
                 log.debug(f"Write {pre_filepath}")
-                self._io_backend.serialize(data, file_)
+                data.to_parquet(file_)
             except Exception as error:
                 log.exception(f"Serialize to {pre_filepath} failed: {error}")
                 raise
@@ -102,7 +35,7 @@ class CacheIO:
 
     def _read(self, filepath):
         with io.open(filepath, "rb") as file_:
-            data = self._io_backend.deserialize(file_)
+            data = pd.read_parquet(file_)
         os.utime(filepath)
         return data
 

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -215,10 +215,6 @@ class StorageCache(CacheIO):
     cache_folder : string
         Base folder within the default cache_root where cached data is
         stored. If cache_root is specified, this parameter is ignored.
-    format_ : string
-        Specify cache file format. 'parquet' or 'csv'.
-        Default is 'parquet'.
-
     """
 
     STOREFORMATVERSION = "v3"
@@ -228,11 +224,10 @@ class StorageCache(CacheIO):
         self,
         max_size=1024,
         cache_root=None,
-        cache_folder="datareservoirio",
-        format_="parquet",
+        cache_folder="datareservoirio"
     ):
         self._max_size = max_size * 1024 * 1024
-        self._cache_format = format_
+        self._cache_format = "parquet"
 
         self._init_cache_dir(cache_root, cache_folder)
         self._cache_index = _CacheIndex(self._cache_path, self._max_size)
@@ -240,7 +235,7 @@ class StorageCache(CacheIO):
         self._evict_lock = Lock()
         self._evict_from_cache()
 
-        super().__init__(format_)
+        super().__init__()
 
     def _init_cache_dir(self, cache_root, cache_folder):
         if cache_root is None:

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -28,23 +28,23 @@ class Storage:
 
     def __init__(self, timeseries_api, session, cache=True, cache_opt=None):
         """
-        Initialize service for working with timeseries data in Azure Blob
-        Storage.
+            Initialize service for working with timeseries data in Azure Blob
+            Storage.
 
-        Parameters
-        ----------
-        timeseries_api: TimeseriesAPI
-            Instance of timeseries API.
-        session : cls
-            An authenticated session that is used in all API calls. Must supply a
-            valid bearer token to all API calls.
-    cache : bool
-        Enable caching (default).
-    cache_opt : dict, optional
-        Configuration object for controlling the series cache.
-        'max_size': max size of cache in megabytes. Default is 1024 MB.
-        'cache_root': cache storage location. See documentation for platform
-        specific defaults.
+            Parameters
+            ----------
+            timeseries_api: TimeseriesAPI
+                Instance of timeseries API.
+            session : cls
+                An authenticated session that is used in all API calls. Must supply a
+                valid bearer token to all API calls.
+        cache : bool
+            Enable caching (default).
+        cache_opt : dict, optional
+            Configuration object for controlling the series cache.
+            'max_size': max size of cache in megabytes. Default is 1024 MB.
+            'cache_root': cache storage location. See documentation for platform
+            specific defaults.
 
         """
         if cache:
@@ -226,12 +226,7 @@ class StorageCache(CacheIO):
     STOREFORMATVERSION = "v3"
     CACHE_THRESHOLD = 24 * 60  # number of rows
 
-    def __init__(
-        self,
-        max_size=1024,
-        cache_root=None,
-        cache_folder="datareservoirio"
-    ):
+    def __init__(self, max_size=1024, cache_root=None, cache_folder="datareservoirio"):
         self._max_size = max_size * 1024 * 1024
         self._cache_format = "parquet"
 

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -266,7 +266,8 @@ class StorageCache(CacheIO):
         """Reset the cache, deleting any stored data."""
         self._evict_entry_root(self.cache_root)
 
-    def get(self, chunk):  # "Counterpart to DirectDownload.get"
+    def get(self, chunk):
+
         """
         Retrieve data from backend. Uses cached data if it is available.
 

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -26,7 +26,7 @@ class Storage:
     Handle download and upload of timeseries data in DataReservoir.io.
     """
 
-    def __init__(self, timeseries_api, session, cache=True, cache_opt=None):
+    def __init__(self, timeseries_api, session, cache=True, cache_opt={}):
         """
         Initialize service for working with timeseries data in Azure Blob
         Storage.
@@ -43,7 +43,7 @@ class Storage:
 
         """
         if cache:
-            storage_cache = StorageCache(format_=cache_opt.pop("format"), **cache_opt)
+            storage_cache = StorageCache(**cache_opt)
         else:
             storage_cache = None
 

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -28,16 +28,16 @@ class Storage:
 
     def __init__(self, timeseries_api, session, cache=True, cache_opt=None):
         """
-            Initialize service for working with timeseries data in Azure Blob
-            Storage.
+        Initialize service for working with timeseries data in Azure Blob
+        Storage.
 
-            Parameters
-            ----------
-            timeseries_api: TimeseriesAPI
-                Instance of timeseries API.
-            session : cls
-                An authenticated session that is used in all API calls. Must supply a
-                valid bearer token to all API calls.
+        Parameters
+        ----------
+        timeseries_api: TimeseriesAPI
+            Instance of timeseries API.
+        session : cls
+            An authenticated session that is used in all API calls. Must supply a
+            valid bearer token to all API calls.
         cache : bool
             Enable caching (default).
         cache_opt : dict, optional
@@ -267,7 +267,6 @@ class StorageCache(CacheIO):
         self._evict_entry_root(self.cache_root)
 
     def get(self, chunk):
-
         """
         Retrieve data from backend. Uses cached data if it is available.
 

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -26,7 +26,7 @@ class Storage:
     Handle download and upload of timeseries data in DataReservoir.io.
     """
 
-    def __init__(self, timeseries_api, session, cache=True, cache_opt={}):
+    def __init__(self, timeseries_api, session, cache=True, cache_opt=None):
         """
         Initialize service for working with timeseries data in Azure Blob
         Storage.
@@ -38,11 +38,17 @@ class Storage:
         session : cls
             An authenticated session that is used in all API calls. Must supply a
             valid bearer token to all API calls.
-
-
+    cache : bool
+        Enable caching (default).
+    cache_opt : dict, optional
+        Configuration object for controlling the series cache.
+        'max_size': max size of cache in megabytes. Default is 1024 MB.
+        'cache_root': cache storage location. See documentation for platform
+        specific defaults.
 
         """
         if cache:
+            cache_opt = {} if cache_opt is None else cache_opt
             storage_cache = StorageCache(**cache_opt)
         else:
             storage_cache = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests
+import warnings
 
 import datareservoirio
 from datareservoirio import Client
@@ -16,7 +17,7 @@ def setUpModule():
 
 
 class Test_Client(unittest.TestCase):
-    @patch("datareservoirio.client.FileCacheDownload")
+    @patch("datareservoirio.storage.StorageCache")
     def setUp(self, mock_cache):
         self.auth = Mock()
 
@@ -110,64 +111,45 @@ class Test_Client(unittest.TestCase):
         self.assertIsInstance(self.client._files_api, Mock)
         self.assertIsInstance(self.client._storage, Mock)
 
-    @patch("datareservoirio.client.DirectDownload")
-    def test_init_with_cache_disabled(self, mock_dl):
-        with Client(self.auth, cache=False):
-            assert mock_dl.call_count == 1
+    @patch("datareservoirio.client.Storage")
+    def test_init_with_cache_disabled(self, mock_storage):
+        Client(self.auth, cache=False)
+        assert not mock_storage.call_args.kwargs["cache"]
 
-    @patch("datareservoirio.client.FileCacheDownload")
-    def test_init_with_defaults_cache_is_enabled_and_format_parquet(self, mock_cache):
-        with Client(self.auth):
-            kwargs = mock_cache.call_args[1]
-            self.assertIn("format_", kwargs)
-            self.assertEqual(kwargs["format_"], "parquet")
-            cache_defaults = Client.CACHE_DEFAULT.copy()
-            cache_defaults["format_"] = cache_defaults.pop("format")
-            mock_cache.assert_called_once_with(**cache_defaults)
+    @patch("datareservoirio.client.Storage")
+    def test_init_with_cache_enabled(self, mock_storage):
+        Client(self.auth, cache=True)
+        assert mock_storage.call_args.kwargs["cache"]
 
-    @patch("datareservoirio.client.FileCacheDownload")
-    def test_init_with_cache_enabled(self, mock_cache):
-        with Client(self.auth, cache=True):
-            cache_defaults = Client.CACHE_DEFAULT.copy()
-            cache_defaults["format_"] = cache_defaults.pop("format")
-            mock_cache.assert_called_once_with(**cache_defaults)
+    @patch("datareservoirio.client.Storage")
+    def test_init_with_cache_format_verify_ignored(self, mock_storage):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
 
-    @patch("datareservoirio.client.FileCacheDownload")
-    def test_init_with_cache_format_csv(self, mock_cache):
-        with Client(self.auth, cache=True, cache_opt={"format": "csv"}):
-            kwargs = mock_cache.call_args[1]
-            self.assertIn("format_", kwargs)
-            self.assertEqual(kwargs["format_"], "csv")
+            Client(self.auth, cache=True, cache_opt={"format": "csv"})
+            assert mock_storage.call_args.kwargs["cache"]
+            assert "format" not in mock_storage.call_args.kwargs["cache_opt"]
 
-    @patch("datareservoirio.client.FileCacheDownload")
-    def test_init_with_cache_format_parquet(self, mock_cache):
-        with Client(self.auth, cache={"format": "parquet"}):
-            kwargs = mock_cache.call_args[1]
-            self.assertIn("format_", kwargs)
-            self.assertEqual(kwargs["format_"], "parquet")
+            assert len(w) == 1
+            assert issubclass(w[-1].category, DeprecationWarning)
 
-    def test_init_with_invalid_cache_format_raises_exception(self):
-        with self.assertRaises(ValueError):
-            with Client(self.auth, cache=True, cache_opt={"format": "bogusformat"}):
-                pass
-
-    @patch("datareservoirio.client.FileCacheDownload")
-    def test_init_with_cache_root(self, mock_cache):
+    @patch("datareservoirio.client.Storage")
+    def test_init_with_cache_root(self, mock_storage):
         cache_defaults = Client.CACHE_DEFAULT.copy()
-        cache_defaults["format_"] = cache_defaults.pop("format")
         cache_defaults["cache_root"] = "a:\\diskett"
 
-        with Client(self.auth, cache=True, cache_opt={"cache_root": "a:\\diskett"}):
-            mock_cache.assert_called_once_with(**cache_defaults)
+        Client(self.auth, cache=True, cache_opt={"cache_root": "a:\\diskett"})
+        assert mock_storage.call_args.kwargs["cache"]
+        assert mock_storage.call_args.kwargs["cache_opt"] == cache_defaults
 
-    @patch("datareservoirio.client.FileCacheDownload")
-    def test_init_with_cache_max_size(self, mock_cache):
+    @patch("datareservoirio.client.Storage")
+    def test_init_with_cache_max_size(self, mock_storage):
         cache_defaults = Client.CACHE_DEFAULT.copy()
-        cache_defaults["format_"] = cache_defaults.pop("format")
         cache_defaults["max_size"] = 10
 
-        with Client(self.auth, cache=True, cache_opt={"max_size": 10}):
-            mock_cache.assert_called_once_with(**cache_defaults)
+        Client(self.auth, cache=True, cache_opt={"max_size": 10})
+        assert mock_storage.call_args.kwargs["cache"]
+        assert mock_storage.call_args.kwargs["cache_opt"] == cache_defaults
 
     def test_ping_request(self):
         self.client._files_api.ping.return_value = {"status": "pong"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -135,21 +135,15 @@ class Test_Client(unittest.TestCase):
 
     @patch("datareservoirio.client.Storage")
     def test_init_with_cache_root(self, mock_storage):
-        cache_defaults = Client.CACHE_DEFAULT.copy()
-        cache_defaults["cache_root"] = "a:\\diskett"
-
         Client(self.auth, cache=True, cache_opt={"cache_root": "a:\\diskett"})
         assert mock_storage.call_args.kwargs["cache"]
-        assert mock_storage.call_args.kwargs["cache_opt"] == cache_defaults
+        assert mock_storage.call_args.kwargs["cache_opt"] == {"cache_root": "a:\\diskett"}
 
     @patch("datareservoirio.client.Storage")
     def test_init_with_cache_max_size(self, mock_storage):
-        cache_defaults = Client.CACHE_DEFAULT.copy()
-        cache_defaults["max_size"] = 10
-
         Client(self.auth, cache=True, cache_opt={"max_size": 10})
         assert mock_storage.call_args.kwargs["cache"]
-        assert mock_storage.call_args.kwargs["cache_opt"] == cache_defaults
+        assert mock_storage.call_args.kwargs["cache_opt"] == {"max_size": 10}
 
     def test_ping_request(self):
         self.client._files_api.ping.return_value = {"status": "pong"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -131,7 +131,7 @@ class Test_Client(unittest.TestCase):
             assert "format" not in mock_storage.call_args.kwargs["cache_opt"]
 
             assert len(w) == 1
-            assert issubclass(w[-1].category, DeprecationWarning)
+            assert issubclass(w[-1].category, FutureWarning)
 
     @patch("datareservoirio.client.Storage")
     def test_init_with_cache_root(self, mock_storage):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,11 @@
 import unittest
+import warnings
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
 import requests
-import warnings
 
 import datareservoirio
 from datareservoirio import Client
@@ -137,7 +137,9 @@ class Test_Client(unittest.TestCase):
     def test_init_with_cache_root(self, mock_storage):
         Client(self.auth, cache=True, cache_opt={"cache_root": "a:\\diskett"})
         assert mock_storage.call_args.kwargs["cache"]
-        assert mock_storage.call_args.kwargs["cache_opt"] == {"cache_root": "a:\\diskett"}
+        assert mock_storage.call_args.kwargs["cache_opt"] == {
+            "cache_root": "a:\\diskett"
+        }
 
     @patch("datareservoirio.client.Storage")
     def test_init_with_cache_max_size(self, mock_storage):

--- a/tests/test_storage/test_cache_engine.py
+++ b/tests/test_storage/test_cache_engine.py
@@ -6,10 +6,7 @@ from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pandas as pd
 
-from datareservoirio.storage.cache_engine import (
-    CacheIO,
-    _CacheIndex,
-)
+from datareservoirio.storage.cache_engine import CacheIO, _CacheIndex
 
 
 class Test_CacheIO(unittest.TestCase):

--- a/tests/test_storage/test_cache_engine.py
+++ b/tests/test_storage/test_cache_engine.py
@@ -8,99 +8,17 @@ import pandas as pd
 
 from datareservoirio.storage.cache_engine import (
     CacheIO,
-    CsvFormat,
-    GenericFormat,
-    ParquetFormat,
     _CacheIndex,
 )
 
 
-class Test_CsvFormat(unittest.TestCase):
-    def test__init(self):
-        file_format = CsvFormat()
-        self.assertIsInstance(file_format, GenericFormat)
-
-    def test_extension(self):
-        file_format = CsvFormat()
-        self.assertEqual(file_format.file_extension, "csv")
-
-    @patch("datareservoirio.storage.cache_engine.pd")
-    def test_deserialize(self, mock_pd):
-        file_format = CsvFormat()
-        file_format.deserialize(io.BytesIO())
-        mock_pd.read_csv.assert_called_once()
-
-    def test_deserialize_actual(self):
-        df = pd.DataFrame({"values": [0, 1, 2, 3, 4]}, index=[0, 1, 2, 3, 4])
-        stream = codecs.getwriter("utf-8")(io.BytesIO())
-        df.to_csv(stream)
-        stream.seek(0)
-
-        file_format = CsvFormat()
-        df_out = file_format.deserialize(stream)
-        pd.testing.assert_frame_equal(df, df_out)
-
-    def test_serialize(self):
-        file_format = CsvFormat()
-        mock_df = MagicMock()
-        stream = io.BytesIO()
-
-        file_format.serialize(mock_df, stream)
-        mock_df.to_csv.assert_called_once()
-
-
-class Test_ParquetFormat(unittest.TestCase):
-    def test__init(self):
-        file_format = ParquetFormat()
-        self.assertIsInstance(file_format, GenericFormat)
-
-    def test_extension(self):
-        file_format = ParquetFormat()
-        self.assertEqual(file_format.file_extension, "parquet")
-
-    @patch("datareservoirio.storage.cache_engine.pd")
-    def test_deserialize(self, mock_pd):
-        file_format = ParquetFormat()
-
-        mock_stream = io.BytesIO()
-        file_format.deserialize(mock_stream)
-        mock_pd.read_parquet.assert_called_once_with(mock_stream)
-
-    def test_deserialize_actual(self):
-        df = pd.DataFrame({"values": [0, 1, 2, 3, 4]}, index=[0, 1, 2, 3, 4])
-        stream = io.BytesIO()
-        df.to_parquet(stream)
-        stream.seek(0)
-
-        file_format = ParquetFormat()
-        df_out = file_format.deserialize(stream)
-        pd.testing.assert_frame_equal(df, df_out)
-
-    def test_serialize(self):
-        file_format = ParquetFormat()
-        mock_df = MagicMock()
-        stream = io.BytesIO()
-
-        file_format.serialize(mock_df, stream)
-        mock_df.to_parquet.assert_called_once_with(stream)
-
-
 class Test_CacheIO(unittest.TestCase):
     def test__init(self):
-        cache_io = CacheIO("parquet")
-        self.assertIsInstance(cache_io._io_backend, ParquetFormat)
-
-        cache_io = CacheIO("csv")
-        self.assertIsInstance(cache_io._io_backend, CsvFormat)
-
-        with self.assertRaises(ValueError):
-            CacheIO("msgpack")
-        with self.assertRaises(ValueError):
-            CacheIO("unicorn")
+        CacheIO()
 
     @patch("os.utime")
     def test_read(self, mock_utime):
-        cache_io = CacheIO("parquet")
+        cache_io = CacheIO()
 
         df = pd.DataFrame({"values": [0, 1, 2, 3, 4]}, index=[0, 1, 2, 3, 4])
         stream = io.BytesIO()
@@ -116,7 +34,7 @@ class Test_CacheIO(unittest.TestCase):
 
     @patch("os.remove")
     def test_delete_with_nonexisting_file_logs_error(self, mock_remove):
-        cache_io = CacheIO("parquet")
+        cache_io = CacheIO()
 
         mock_remove.side_effect = Exception
 
@@ -126,7 +44,7 @@ class Test_CacheIO(unittest.TestCase):
 
     @patch("os.rename")
     def test_write(self, mock_rename):
-        cache_io = CacheIO("parquet")
+        cache_io = CacheIO()
         df = MagicMock()
 
         with patch("io.open", mock_open()):

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -10,11 +10,7 @@ import pytest
 import requests
 
 from datareservoirio.appdirs import user_cache_dir
-from datareservoirio.storage import (
-    BaseDownloader,
-    StorageCache,
-    Storage,
-)
+from datareservoirio.storage import BaseDownloader, Storage, StorageCache
 from datareservoirio.storage.storage import (
     _blob_to_df,
     _df_to_blob,
@@ -159,11 +155,7 @@ class Test_Storage(unittest.TestCase):
             ]
         }
 
-        self.storage = Storage(
-            self._timeseries_api,
-            session=self.session,
-            cache=False
-        )
+        self.storage = Storage(self._timeseries_api, session=self.session, cache=False)
 
     @patch("datareservoirio.storage.storage._blob_to_df")
     def test_get(self, mock_remote_get):
@@ -172,7 +164,9 @@ class Test_Storage(unittest.TestCase):
 
         data_out = self.storage.get(self.tid, 2, 3)
 
-        mock_remote_get.assert_called_once_with("https:://go-here-for-blob.com/segment_0")
+        mock_remote_get.assert_called_once_with(
+            "https:://go-here-for-blob.com/segment_0"
+        )
         pd.testing.assert_frame_equal(data_out, data_remote)
 
     def test_put(self):
@@ -203,7 +197,7 @@ class Test_BaseDownloader(unittest.TestCase):
             "Files": [
                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]}
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]},
             ]
         }
 
@@ -211,11 +205,11 @@ class Test_BaseDownloader(unittest.TestCase):
             pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}),
             pd.DataFrame({"index": [3, 4, 5], "values": [5.0, 4.0, 5.0]}),
             pd.DataFrame({"index": [1, 5, 9], "values": [9.0, 8.0, 1.0]}),
-            ]
+        ]
 
         df_expected = pd.DataFrame(
-                {"index": [1, 2, 3, 4, 5, 9], "values": [9.0, 2.0, 5.0, 4.0, 8.0, 1.0]}
-            )
+            {"index": [1, 2, 3, 4, 5, 9], "values": [9.0, 2.0, 5.0, 4.0, 8.0, 1.0]}
+        )
 
         base_downloader = BaseDownloader()
 
@@ -226,8 +220,8 @@ class Test_BaseDownloader(unittest.TestCase):
         calls = [
             call("https:://go-here-for-blob.com/segment_0"),
             call("https:://go-here-for-blob.com/segment_1"),
-            call("https:://go-here-for-blob.com/segment_2")
-            ]
+            call("https:://go-here-for-blob.com/segment_2"),
+        ]
         mock_remote_get.assert_has_calls(calls)
 
     @patch("datareservoirio.storage.storage._blob_to_df")
@@ -236,7 +230,7 @@ class Test_BaseDownloader(unittest.TestCase):
             "Files": [
                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]}
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]},
             ]
         }
 
@@ -244,11 +238,11 @@ class Test_BaseDownloader(unittest.TestCase):
             pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}),
             pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}),
             pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}),
-            ]
+        ]
 
         df_expected = pd.DataFrame(
-                {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
-            )
+            {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
+        )
 
         base_downloader = BaseDownloader()
 
@@ -259,13 +253,9 @@ class Test_BaseDownloader(unittest.TestCase):
         calls = [
             call("https:://go-here-for-blob.com/segment_0"),
             call("https:://go-here-for-blob.com/segment_1"),
-            call("https:://go-here-for-blob.com/segment_2")
-            ]
+            call("https:://go-here-for-blob.com/segment_2"),
+        ]
         mock_remote_get.assert_has_calls(calls)
-
-
-
-
 
         # mock_backend = MagicMock()
         # base_downloader = BaseDownloader(mock_backend)
@@ -295,6 +285,7 @@ class Test_BaseDownloader(unittest.TestCase):
         #     df_out = base_downloader.get(response)
 
         # pd.testing.assert_frame_equal(df_expected, df_out)
+
     def test_get_empty(self):
         mock_backend = MagicMock()
         base_downloader = BaseDownloader(mock_backend)
@@ -344,11 +335,11 @@ class Test_BaseDownloader(unittest.TestCase):
 
         mock_remote_get.side_effect = [
             pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
-            ]
+        ]
 
         df_expected = pd.DataFrame(
-                {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
-            ).set_index("index")
+            {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
+        ).set_index("index")
 
         base_downloader = BaseDownloader()
 
@@ -363,11 +354,11 @@ class Test_BaseDownloader(unittest.TestCase):
 
         mock_remote_get.side_effect = [
             pd.DataFrame({"index": [1, 2, 2, 3], "values": [1.0, 2.0, 2.0, 3.0]})
-            ]
+        ]
 
         df_expected = pd.DataFrame(
-                {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
-            ).set_index("index")
+            {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
+        ).set_index("index")
 
         base_downloader = BaseDownloader()
 
@@ -381,7 +372,7 @@ class Test_BaseDownloader(unittest.TestCase):
         chunk = [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]
         mock_remote_get.side_effect = [
             pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
-            ]
+        ]
 
         df_expected = pd.DataFrame(
             {
@@ -393,7 +384,9 @@ class Test_BaseDownloader(unittest.TestCase):
         base_downloader = BaseDownloader()
         df_out = base_downloader._download_chunks_as_dataframe(chunk)
 
-        mock_remote_get.assert_called_once_with("https:://go-here-for-blob.com/segment_0")
+        mock_remote_get.assert_called_once_with(
+            "https:://go-here-for-blob.com/segment_0"
+        )
         pd.testing.assert_frame_equal(df_expected, df_out)
 
     def test__download_chunks_as_dataframe_no_chunks(self):
@@ -426,9 +419,7 @@ class Test_StorageCache(unittest.TestCase):
         cacheindex_patcher = patch("datareservoirio.storage.storage._CacheIndex")
         self._cacheindex_patch = cacheindex_patcher.start()
 
-        evict_patcher = patch(
-            "datareservoirio.storage.StorageCache._evict_from_cache"
-        )
+        evict_patcher = patch("datareservoirio.storage.StorageCache._evict_from_cache")
         self._evict_patch = evict_patcher.start()
 
         self.addCleanup(patch.stopall)
@@ -531,10 +522,7 @@ class Test_StorageCache(unittest.TestCase):
             )
 
     def test_put_data_to_cache_tiny(self):
-        chunk = {
-            "Path": "abc123def456",
-            "ContentMd5": "md5-123"
-        }
+        chunk = {"Path": "abc123def456", "ContentMd5": "md5-123"}
         df = pd.DataFrame({"values": [1.0, 2.0, 3.0]}, index=[1, 2, 3])
 
         cache = StorageCache()
@@ -542,10 +530,7 @@ class Test_StorageCache(unittest.TestCase):
         self._cacheindex_patch._get_filepath.assert_not_called()
 
     def test_put_data_to_cache(self):
-        chunk = {
-            "Path": "abc123def456",
-            "ContentMd5": "md5-123"
-        }
+        chunk = {"Path": "abc123def456", "ContentMd5": "md5-123"}
 
         df = pd.DataFrame(
             {"values": np.arange(24 * 61)}, index=np.arange(24 * 61, dtype=int)

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -11,7 +11,6 @@ import pytest
 from datareservoirio.appdirs import user_cache_dir
 from datareservoirio.storage import (
     BaseDownloader,
-    DirectDownload,
     FileCacheDownload,
     Storage,
 )
@@ -113,24 +112,33 @@ def bytesio_with_memory():
 class Test_Storage(unittest.TestCase):
     def setUp(self):
         self._timeseries_api = Mock()
-        self._files_api = Mock()
-        self.downloader = Mock()
         self.session = Mock()
 
         self.tid = "abc-123-xyz"
 
+        self._timeseries_api.download_days.return_value = {
+            "Files": [
+                {
+                    "Chunks": [
+                        {"Endpoint": "https:://go-here-for-blob.com/segment_0"},
+                    ]
+                },
+            ]
+        }
+
         self.storage = Storage(
             self._timeseries_api,
-            downloader=self.downloader,
             session=self.session,
         )
 
-    def test_get(self):
+    @patch("datareservoirio.storage.storage._blob_to_df")
+    def test_get(self, mock_remote_get):
         data_remote = pd.DataFrame({"index": [1, 2, 3, 4], "values": [1, 2, 3, 4]})
-        self.downloader.get.return_value = data_remote
+        mock_remote_get.return_value = data_remote.copy()  # Inplace manipulation occurs
 
         data_out = self.storage.get(self.tid, 2, 3)
 
+        mock_remote_get.assert_called_once_with("https:://go-here-for-blob.com/segment_0")
         pd.testing.assert_frame_equal(data_out, data_remote)
 
     def test_put(self):
@@ -151,84 +159,108 @@ class Test_Storage(unittest.TestCase):
         )
 
 
-class Test_DirectDownload(unittest.TestCase):
-    @patch("datareservoirio.storage.storage._blob_to_df")
-    def test_get(self, mock_remote_get):
-        params = {"Endpoint": "https:://go-here-for-blob.com"}
-        downloader = DirectDownload()
-        downloader.get(params)
-
-        mock_remote_get.assert_called_once_with(params["Endpoint"])
-
-
 class Test_BaseDownloader(unittest.TestCase):
     def test_init(self):
-        mock_backend = MagicMock()
-        base_downloader = BaseDownloader(mock_backend)
-        self.assertEqual(base_downloader._backend, mock_backend)
+        BaseDownloader()
 
-    def test_get(self):
-        mock_backend = MagicMock()
-        base_downloader = BaseDownloader(mock_backend)
-
+    @patch("datareservoirio.storage.storage._blob_to_df")
+    def test_get(self, mock_remote_get):
         response = {
-            "Files": [{"Chunks": "abc1"}, {"Chunks": "abc2"}, {"Chunks": "abc3"}]
+            "Files": [
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]}
+            ]
         }
 
-        with patch.object(
-            base_downloader, "_download_chunks_as_dataframe"
-        ) as mock_download:
-            mock_download.side_effect = [
-                pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}).set_index(
-                    "index"
-                ),
-                pd.DataFrame({"index": [3, 4, 5], "values": [5.0, 4.0, 5.0]}).set_index(
-                    "index"
-                ),
-                pd.DataFrame({"index": [1, 5, 9], "values": [9.0, 8.0, 1.0]}).set_index(
-                    "index"
-                ),
+        mock_remote_get.side_effect = [
+            pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}),
+            pd.DataFrame({"index": [3, 4, 5], "values": [5.0, 4.0, 5.0]}),
+            pd.DataFrame({"index": [1, 5, 9], "values": [9.0, 8.0, 1.0]}),
             ]
 
-            df_expected = pd.DataFrame(
+        df_expected = pd.DataFrame(
                 {"index": [1, 2, 3, 4, 5, 9], "values": [9.0, 2.0, 5.0, 4.0, 8.0, 1.0]}
             )
-            df_out = base_downloader.get(response)
+
+        base_downloader = BaseDownloader()
+
+        df_out = base_downloader.get(response)
 
         pd.testing.assert_frame_equal(df_expected, df_out)
 
-        calls = [call("abc1"), call("abc2"), call("abc3")]
-        mock_download.assert_has_calls(calls)
+        calls = [
+            call("https:://go-here-for-blob.com/segment_0"),
+            call("https:://go-here-for-blob.com/segment_1"),
+            call("https:://go-here-for-blob.com/segment_2")
+            ]
+        mock_remote_get.assert_has_calls(calls)
 
-    def test_get_with_text_data(self):
-        mock_backend = MagicMock()
-        base_downloader = BaseDownloader(mock_backend)
-
+    @patch("datareservoirio.storage.storage._blob_to_df")
+    def test_get_with_text_data(self, mock_remote_get):
         response = {
-            "Files": [{"Chunks": "abc1"}, {"Chunks": "abc2"}, {"Chunks": "abc3"}]
+            "Files": [
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
+                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]}
+            ]
         }
 
-        with patch.object(
-            base_downloader, "_download_chunks_as_dataframe"
-        ) as mock_download:
-            mock_download.side_effect = [
-                pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}).set_index(
-                    "index"
-                ),
-                pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}).set_index(
-                    "index"
-                ),
-                pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}).set_index(
-                    "index"
-                ),
+        mock_remote_get.side_effect = [
+            pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}),
+            pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}),
+            pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}),
             ]
 
-            df_expected = pd.DataFrame(
+        df_expected = pd.DataFrame(
                 {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
             )
-            df_out = base_downloader.get(response)
+
+        base_downloader = BaseDownloader()
+
+        df_out = base_downloader.get(response)
 
         pd.testing.assert_frame_equal(df_expected, df_out)
+
+        calls = [
+            call("https:://go-here-for-blob.com/segment_0"),
+            call("https:://go-here-for-blob.com/segment_1"),
+            call("https:://go-here-for-blob.com/segment_2")
+            ]
+        mock_remote_get.assert_has_calls(calls)
+
+
+
+
+
+        # mock_backend = MagicMock()
+        # base_downloader = BaseDownloader(mock_backend)
+
+        # response = {
+        #     "Files": [{"Chunks": "abc1"}, {"Chunks": "abc2"}, {"Chunks": "abc3"}]
+        # }
+
+        # with patch.object(
+        #     base_downloader, "_download_chunks_as_dataframe"
+        # ) as mock_download:
+        #     mock_download.side_effect = [
+        #         pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}).set_index(
+        #             "index"
+        #         ),
+        #         pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}).set_index(
+        #             "index"
+        #         ),
+        #         pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}).set_index(
+        #             "index"
+        #         ),
+        #     ]
+
+        #     df_expected = pd.DataFrame(
+        #         {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
+        #     )
+        #     df_out = base_downloader.get(response)
+
+        # pd.testing.assert_frame_equal(df_expected, df_out)
 
     def test__combine_first_no_overlap(self):
         df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
@@ -258,56 +290,62 @@ class Test_BaseDownloader(unittest.TestCase):
         df_out = BaseDownloader._combine_first(df1, df2)
         pd.testing.assert_series_equal(df_expected, df_out)
 
-    def test__download_verified_chunk(self):
-        df = pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
+    @patch("datareservoirio.storage.storage._blob_to_df")
+    def test__download_verified_chunk(self, mock_remote_get):
+        chunk = {"Endpoint": "https:://go-here-for-blob.com/segment_0"}
 
-        mock_backend = MagicMock()
-        mock_backend.get.return_value = df
+        mock_remote_get.side_effect = [
+            pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
+            ]
 
-        df_expected = df.set_index("index")
+        df_expected = pd.DataFrame(
+                {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
+            ).set_index("index")
 
-        base_downloader = BaseDownloader(mock_backend)
-        df_out = base_downloader._download_verified_chunk("chunk")
-        mock_backend.get.assert_called_once_with("chunk")
+        base_downloader = BaseDownloader()
 
-        pd.testing.assert_frame_equal(df_expected, df_out)
-
-    def test__download_verified_chunk_w_duplicates(self):
-        df = pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
-        mock_backend = MagicMock()
-        mock_backend.get.return_value = df
-
-        df_expected = df.set_index("index")
-
-        base_downloader = BaseDownloader(mock_backend)
-        df_out = base_downloader._download_verified_chunk("chunk")
-        mock_backend.get.assert_called_once_with("chunk")
+        df_out = base_downloader._download_verified_chunk(chunk)
+        mock_remote_get.assert_called_once_with(chunk["Endpoint"])
 
         pd.testing.assert_frame_equal(df_expected, df_out)
 
-    def test__download_chunks_as_dataframe(self):
-        mock_backend = MagicMock()
-        mock_backend.get.side_effect = [
-            pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}),
-            pd.DataFrame({"index": [4, 5, 6], "values": [3.0, 4.0, 5.0]}),
-            pd.DataFrame({"index": [7, 8, 9], "values": [5.0, 6.0, 7.0]}),
-        ]
+    @patch("datareservoirio.storage.storage._blob_to_df")
+    def test__download_verified_chunk_w_duplicates(self, mock_remote_get):
+        chunk = {"Endpoint": "https:://go-here-for-blob.com/segment_0"}
+
+        mock_remote_get.side_effect = [
+            pd.DataFrame({"index": [1, 2, 2, 3], "values": [1.0, 2.0, 2.0, 3.0]})
+            ]
+
+        df_expected = pd.DataFrame(
+                {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
+            ).set_index("index")
+
+        base_downloader = BaseDownloader()
+
+        df_out = base_downloader._download_verified_chunk(chunk)
+        mock_remote_get.assert_called_once_with(chunk["Endpoint"])
+
+        pd.testing.assert_frame_equal(df_expected, df_out)
+
+    @patch("datareservoirio.storage.storage._blob_to_df")
+    def test__download_chunks_as_dataframe(self, mock_remote_get):
+        chunk = [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]
+        mock_remote_get.side_effect = [
+            pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
+            ]
 
         df_expected = pd.DataFrame(
             {
-                "index": [1, 2, 3, 4, 5, 6, 7, 8, 9],
-                "values": [1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0, 6.0, 7.0],
+                "index": [1, 2, 3],
+                "values": [1.0, 2.0, 3.0],
             }
         ).set_index("index")
 
-        base_downloader = BaseDownloader(mock_backend)
-        df_out = base_downloader._download_chunks_as_dataframe(
-            ["chunk1", "chunk2", "chunk3"]
-        )
+        base_downloader = BaseDownloader()
+        df_out = base_downloader._download_chunks_as_dataframe(chunk)
 
-        calls = [call("chunk1"), call("chunk2"), call("chunk3")]
-        mock_backend.get.assert_has_calls(calls)
-
+        mock_remote_get.assert_called_once_with("https:://go-here-for-blob.com/segment_0")
         pd.testing.assert_frame_equal(df_expected, df_out)
 
 

--- a/tests_integration/test_client.py
+++ b/tests_integration/test_client.py
@@ -15,7 +15,6 @@ from tests_integration._auth import CLIENT
 class Test_Client(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-
         cls.df_1 = pd.Series(np.arange(100.0), index=np.arange(0, 100))
         cls.df_2 = pd.Series(np.arange(100.0), index=np.arange(50, 150))
         cls.df_3 = pd.Series(np.arange(50.0), index=np.arange(125, 175))

--- a/tests_integration/test_client_metadata.py
+++ b/tests_integration/test_client_metadata.py
@@ -16,7 +16,6 @@ class Test_ClientMetadata(unittest.TestCase):
         self.auth.close()
 
     def test_metadata_set_with_data_returns_id_of_existing_metadata(self):
-
         response1 = self.client.metadata_set(
             "system.integration",
             "test_metadata_set",

--- a/tests_integration/test_storage/test_basedownloader_directdownload.py
+++ b/tests_integration/test_storage/test_basedownloader_directdownload.py
@@ -36,7 +36,6 @@ class Test_DirectDownload(unittest.TestCase):
         self.auth.close()
 
     def test_get(self):
-
         response = self.timeseries_api.create()
         myfileid = self.token_fileid
 

--- a/tests_integration/test_timeseries_api.py
+++ b/tests_integration/test_timeseries_api.py
@@ -84,7 +84,6 @@ class Test_TimeSeriesApi(unittest.TestCase):
         self.api.delete(response["TimeSeriesId"])
 
     def test_create_data_delete(self):
-
         response = self.api.create_with_data(self.token_fileid[0])
 
         info = self.api.info(response["TimeSeriesId"])
@@ -107,7 +106,6 @@ class Test_TimeSeriesApi(unittest.TestCase):
             self.api.info(response["TimeSeriesId"])
 
     def test_create_add_overlap_data_delete(self):
-
         response = self.api.create_with_data(self.token_fileid[0])
 
         response = self.api.add(response["TimeSeriesId"], self.token_fileid[1])


### PR DESCRIPTION
### This PR is related to user story DST-388

## Description
This PR aims to simplify storage and cache handling code. Key changes are:
* Deprecate `DirectDownload` and `FileCacheDownload`. Logic is moved to `BaseDownloader` and `Storage`.
    * `BaseDownloader` is to be deprecated next 👍 
* Rename `FileCacheDownload` -> `StorageCache`
* `StorageCache` deals only with local cache handling. "Try cache, then download and write to cache" logic moved to `BaseDownloader._download_verified_chunk`
* `Storage` initiates necessary cache stuff when needed.
* `Client.__init__` is significantly cleaned up as `DirectDownload` and `FileCacheDownload` is deprecated.
* Support for choosing cache file format deprecated. Uses `parquet`. Period. 

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

