### PR TITLE
Fix issues with failed downloads due to SAS-key expiry

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -280,8 +280,8 @@ class Client:
 
         # make an "expolotary" request
         response = self._auth_session.get(
-            environment.api_base_url +
-            f"timeseries/{series_id}/data/days?start={start}&end={end}"
+            environment.api_base_url
+            + f"timeseries/{series_id}/data/days?start={start}&end={end}"
         )
         response.raise_for_status()
         response_json = response.json()

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -286,7 +286,7 @@ class Client:
         response.raise_for_status()
         response_json = response.json()
 
-        if response_json:
+        if response_json["Files"]:
             with ThreadPoolExecutor(max_workers=None) as e:
                 futures = [
                     e.submit(

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -538,7 +538,7 @@ def _timeseries_available_days(response_json):
     Each day is represented by the first nanoseconds since epoch
     of that day.
 
-    The list is obtained from the response of an "explotary" call to
+    The list is obtained from the response of an "exploratory" call to
     ``api/timeseries/data/days?start={start}&end={end}``.
 
     Notes

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -543,7 +543,7 @@ def _timeseries_available_days(response_json):
 
     Notes
     -----
-    This is a bit hacky, since it assumes a few thing about the response and
+    This is a bit hacky, since it assumes a few things about the response and
     the inner workings of the backend.
     """
     days = set()

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -278,7 +278,7 @@ class Client:
         if start >= end:
             raise ValueError("start must be before end")
 
-        # make an "expolotary" request
+        # make an "exploratory" request
         response = self._auth_session.get(
             environment.api_base_url
             + f"timeseries/{series_id}/data/days?start={start}&end={end}"

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import timeit
 import warnings
 from operator import itemgetter
 
@@ -280,7 +279,13 @@ class Client:
         if start >= end:
             raise ValueError("start must be before end")
 
-        time_start = timeit.default_timer()
+        # split start, end to sequence of start_day, end_day list
+        # for each start-end pair, generate url to rest call.
+        # submit each call to storage.get(target_url)  -> (it downloads and merges in sequence)
+        #    make it work sequencially first, upgrade to concurrent later.
+        # collect all in correct sequence
+        # concat collection
+        # set_index, squeeze, and slice
 
         log.debug("Getting series range")
         series = (
@@ -297,9 +302,6 @@ class Client:
 
         if convert_date:
             series.index = pd.to_datetime(series.index, utc=True)
-
-        time_end = timeit.default_timer()
-        log.info(f"Download series dataframe took {time_end - time_start} seconds")
 
         return series
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -55,9 +55,7 @@ class Client:
                     FutureWarning,
                 )
 
-        self._storage = Storage(
-            self._timeseries_api, self._auth_session, cache=cache, cache_opt=cache_opt
-        )
+        self._storage = Storage(self._auth_session, cache=cache, cache_opt=cache_opt)
 
     def ping(self):
         """

--- a/datareservoirio/storage/__init__.py
+++ b/datareservoirio/storage/__init__.py
@@ -1,1 +1,1 @@
-from .storage import BaseDownloader, Storage, StorageCache
+from .storage import Storage, StorageCache

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -139,7 +139,8 @@ class Storage:
 
         Notes
         -----
-        This is a hacky solution assuming alot about the REST API respone from
+        This is a hacky solution assuming alot about the REST API response from
+
         ``/data/days?start={start}&end={end}``.
         """
         chunks = defaultdict(list)

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -102,12 +102,12 @@ class Storage:
         except StopIteration:
             return pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
         else:
-            df = self._blob_to_df(chunk_i)
+            df = self._blob_to_df(chunk_i).set_index("index")
 
         for chunk_i in blob_sequence:
-            df.combine_first(self._blob_to_df(chunk_i))
+            df = df.combine_first(self._blob_to_df(chunk_i).set_index("index"))
 
-        return df
+        return df.reset_index()
 
     def _blob_to_df(self, chunk):
         """

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -84,6 +84,7 @@ class Storage:
         return
 
     def get(self, timeseries_id, start, end):
+        # (target_url | start and end already resolved in the url)
         """
         Get a range of data for a timeseries.
 
@@ -97,11 +98,20 @@ class Storage:
             End time of the range, in nanoseconds since EPOCH
 
         """
+        # make REST call to timeseries/days
+        # Unpack and put blob urls in sequence
+        # download 1-by-1 and update using dict
+        # return final merged.
+
+        # No extra logic, just download and merge in sequence.
+        # Optimal use: target_url covers only 1 day.
+
         log.debug("getting day file inventory")
         response = self._timeseries_api.download_days(timeseries_id, start, end)
         df = self._downloader.get(response)
         return df
 
+# dict merge function.
 
 class BaseDownloader:
     """

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -95,7 +95,9 @@ class Storage:
         response = self._session.request("GET", target_url)
         response.raise_for_status()
 
-        blob_sequence = iter(reversed(self._days_response_url_sequence(response.json())))
+        blob_sequence = iter(
+            reversed(self._days_response_url_sequence(response.json()))
+        )
 
         try:
             chunk_i = next(blob_sequence)

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -92,7 +92,8 @@ class Storage:
             Pandas DataFrame with two columns, ``index`` and ``values``.
 
         """
-        response = self._session.request("GET", target_url)
+        response = self._session.get(target_url)
+
         response.raise_for_status()
 
         blob_sequence = iter(

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -128,7 +128,8 @@ class Storage:
     @staticmethod
     def _days_response_url_sequence(response_json):
         """
-        Flatten resposne from ``/data/days?start={start}&end={end}``
+        Flatten response from ``/data/days?start={start}&end={end}``
+
         to a sequence of dictionaries with endpoint URLs, path, and
         md5 hash of blobs.
 

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -133,7 +133,8 @@ class Storage:
         to a sequence of dictionaries with endpoint URLs, path, and
         md5 hash of blobs.
 
-        The order indicate the priority where item ``n+1`` takes presedence
+        The order indicate the priority where item ``n+1`` takes precedence
+
         over item ``n`` and so on.
 
         Notes

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -291,25 +291,25 @@ class Test_Client(unittest.TestCase):
         self.client._timeseries_api.delete.assert_called_once_with(self.timeseries_id)
         self.assertEqual(response, expected_response)
 
-    def test_get_with_defaults(self):
-        index = np.array([1, 2, 3, 4, 5, 6])
-        values = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    # def test_get_with_defaults(self):
+    #     index = np.array([1, 2, 3, 4, 5, 6])
+    #     values = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
 
-        self._storage.get.return_value = pd.DataFrame(
-            {"index": index, "values": values}
-        )
-        response_expected = pd.Series(
-            values, index=pd.to_datetime(index, utc=True), name="values"
-        )
+    #     self._storage.get.return_value = pd.DataFrame(
+    #         {"index": index, "values": values}
+    #     )
+    #     response_expected = pd.Series(
+    #         values, index=pd.to_datetime(index, utc=True), name="values"
+    #     )
 
-        response = self.client.get(self.timeseries_id)
+    #     response = self.client.get(self.timeseries_id)
 
-        self.client._storage.get.assert_called_once_with(
-            self.timeseries_id,
-            datareservoirio.client._START_DEFAULT,
-            datareservoirio.client._END_DEFAULT - 1,
-        )
-        pd.testing.assert_series_equal(response, response_expected)
+    #     self.client._storage.get.assert_called_once_with(
+    #         self.timeseries_id,
+    #         datareservoirio.client._START_DEFAULT,
+    #         datareservoirio.client._END_DEFAULT - 1,
+    #     )
+    #     pd.testing.assert_series_equal(response, response_expected)
 
     def test_get_with_convert_date_returns_series(self):
         index = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -328,8 +328,8 @@ class Test_Client(unittest.TestCase):
         response = self.client.get(self.timeseries_id, start, end, convert_date=True)
 
         self.client._storage.get.assert_called_once_with(
-            self.timeseries_id, start, end - 1
-        )
+            f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
+            )
 
         pd.testing.assert_series_equal(response, series_with_dt, check_index_type=True)
 
@@ -348,8 +348,8 @@ class Test_Client(unittest.TestCase):
         response = self.client.get(self.timeseries_id, start, end, convert_date=False)
 
         self.client._storage.get.assert_called_once_with(
-            self.timeseries_id, start, end - 1
-        )
+            f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
+            )
 
         pd.testing.assert_series_equal(response, series_with_dt, check_index_type=True)
 
@@ -366,7 +366,9 @@ class Test_Client(unittest.TestCase):
             end="1970-01-01 00:00:00.000000004",
         )
 
-        self.client._storage.get.assert_called_once_with(self.timeseries_id, 1, 3)
+        self.client._storage.get.assert_called_once_with(
+            f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
+            )
 
     def test_get_with_emptytimeseries_return_empty(self):
         index = np.array([10, 11, 12])
@@ -394,13 +396,11 @@ class Test_Client(unittest.TestCase):
         response_expected = pd.Series(name="values", dtype="object")
         response_expected.index = pd.to_datetime(response_expected.index, utc=True)
 
-        response = self.client.get(self.timeseries_id)
+        response = self.client.get(self.timeseries_id, 10, 20)
 
         self.client._storage.get.assert_called_once_with(
-            self.timeseries_id,
-            datareservoirio.client._START_DEFAULT,
-            datareservoirio.client._END_DEFAULT - 1,
-        )
+            f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
+            )
         pd.testing.assert_series_equal(response, response_expected)
 
     def test_get_with_raise_empty_throws(self):
@@ -442,7 +442,8 @@ class Test_Client(unittest.TestCase):
             end="1970-01-01 00:00:00.000000004",
         )
 
-        self.client._storage.get.assert_called_once_with(self.timeseries_id, 1, 3)
+        self.client._storage.get.assert_called_once_with(
+            "https://reservoir-api-qa.4subsea.net/api/timeseries/abc-123-xyz/data/days?start=0&end=0")
 
     def test_search(self):
         self.client.search("test_namespace", "test_key", "test_name", 123)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -307,24 +307,26 @@ class Test_Client(unittest.TestCase):
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.json.return_value = {
-                "Files": [{
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 0,
-                        },
-                    ],
-                }]
-                }
+                "Files": [
+                    {
+                        "Index": 0,
+                        "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                        "Chunks": [
+                            {
+                                "Account": "permanentprodu003p144",
+                                "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                                "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                                "Container": "data",
+                                "Path": "segment_0.csv",
+                                "Endpoint": "https://go-here-for-blob.com/segment_0",
+                                "ContentMd5": "md5_0",
+                                "VersionId": "2021-08-31T13:53:27.3874185Z",
+                                "DaysSinceEpoch": 0,
+                            },
+                        ],
+                    }
+                ]
+            }
             mock_get.return_value = mock_response
 
             response = self.client.get(self.timeseries_id)
@@ -349,33 +351,37 @@ class Test_Client(unittest.TestCase):
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.json.return_value = {
-                "Files": [{
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 0,
-                        },
-                    ],
-                }]
-                }
+                "Files": [
+                    {
+                        "Index": 0,
+                        "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                        "Chunks": [
+                            {
+                                "Account": "permanentprodu003p144",
+                                "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                                "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                                "Container": "data",
+                                "Path": "segment_0.csv",
+                                "Endpoint": "https://go-here-for-blob.com/segment_0",
+                                "ContentMd5": "md5_0",
+                                "VersionId": "2021-08-31T13:53:27.3874185Z",
+                                "DaysSinceEpoch": 0,
+                            },
+                        ],
+                    }
+                ]
+            }
             mock_get.return_value = mock_response
             self.client._storage.get.return_value = pd.DataFrame(
                 {"index": index, "values": values}
             )
-            response = self.client.get(self.timeseries_id, start, end, convert_date=True)
+            response = self.client.get(
+                self.timeseries_id, start, end, convert_date=True
+            )
 
         self.client._storage.get.assert_called_once_with(
             f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
-            )
+        )
 
         pd.testing.assert_series_equal(response, series_with_dt, check_index_type=True)
 
@@ -396,30 +402,34 @@ class Test_Client(unittest.TestCase):
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.json.return_value = {
-                "Files": [{
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 0,
-                        },
-                    ],
-                }]
-                }
+                "Files": [
+                    {
+                        "Index": 0,
+                        "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                        "Chunks": [
+                            {
+                                "Account": "permanentprodu003p144",
+                                "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                                "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                                "Container": "data",
+                                "Path": "segment_0.csv",
+                                "Endpoint": "https://go-here-for-blob.com/segment_0",
+                                "ContentMd5": "md5_0",
+                                "VersionId": "2021-08-31T13:53:27.3874185Z",
+                                "DaysSinceEpoch": 0,
+                            },
+                        ],
+                    }
+                ]
+            }
             mock_get.return_value = mock_response
-            response = self.client.get(self.timeseries_id, start, end, convert_date=False)
+            response = self.client.get(
+                self.timeseries_id, start, end, convert_date=False
+            )
 
         self.client._storage.get.assert_called_once_with(
             f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
-            )
+        )
 
         pd.testing.assert_series_equal(response, series_with_dt, check_index_type=True)
 
@@ -434,24 +444,26 @@ class Test_Client(unittest.TestCase):
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.json.return_value = {
-                "Files": [{
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 0,
-                        },
-                    ],
-                }]
-                }
+                "Files": [
+                    {
+                        "Index": 0,
+                        "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                        "Chunks": [
+                            {
+                                "Account": "permanentprodu003p144",
+                                "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                                "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                                "Container": "data",
+                                "Path": "segment_0.csv",
+                                "Endpoint": "https://go-here-for-blob.com/segment_0",
+                                "ContentMd5": "md5_0",
+                                "VersionId": "2021-08-31T13:53:27.3874185Z",
+                                "DaysSinceEpoch": 0,
+                            },
+                        ],
+                    }
+                ]
+            }
             mock_get.return_value = mock_response
 
             self.client.get(
@@ -462,7 +474,7 @@ class Test_Client(unittest.TestCase):
 
         self.client._storage.get.assert_called_once_with(
             f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
-            )
+        )
 
     def test_get_with_emptytimeseries_return_empty(self):
         index = np.array([10, 11, 12])
@@ -478,24 +490,26 @@ class Test_Client(unittest.TestCase):
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.json.return_value = {
-                "Files": [{
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 0,
-                        },
-                    ],
-                }]
-                }
+                "Files": [
+                    {
+                        "Index": 0,
+                        "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                        "Chunks": [
+                            {
+                                "Account": "permanentprodu003p144",
+                                "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                                "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                                "Container": "data",
+                                "Path": "segment_0.csv",
+                                "Endpoint": "https://go-here-for-blob.com/segment_0",
+                                "ContentMd5": "md5_0",
+                                "VersionId": "2021-08-31T13:53:27.3874185Z",
+                                "DaysSinceEpoch": 0,
+                            },
+                        ],
+                    }
+                ]
+            }
             mock_get.return_value = mock_response
 
             response = self.client.get(
@@ -518,46 +532,8 @@ class Test_Client(unittest.TestCase):
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.json.return_value = {
-                "Files": [{
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 0,
-                        },
-                    ],
-                }]
-                }
-            mock_get.return_value = mock_response
-
-            response = self.client.get(self.timeseries_id, 10, 20)
-
-        self.client._storage.get.assert_called_once_with(
-            f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
-            )
-        pd.testing.assert_series_equal(response, response_expected)
-
-    def test_get_with_raise_empty_throws(self):
-        index = np.array([6, 7, 8, 9, 10])
-        values = np.array([6.0, 7.0, 8.0, 9.0, 10.0])
-        self._storage.get.return_value = pd.DataFrame(
-            {"index": index, "values": values}
-        )
-
-        with self.assertRaises(ValueError):
-            with patch.object(self.auth, "get") as mock_get:
-                mock_response = Mock()
-                mock_response.raise_for_status.return_value = None
-                mock_response.json.return_value = {
-                    "Files": [{
+                "Files": [
+                    {
                         "Index": 0,
                         "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
                         "Chunks": [
@@ -573,8 +549,50 @@ class Test_Client(unittest.TestCase):
                                 "DaysSinceEpoch": 0,
                             },
                         ],
-                    }]
                     }
+                ]
+            }
+            mock_get.return_value = mock_response
+
+            response = self.client.get(self.timeseries_id, 10, 20)
+
+        self.client._storage.get.assert_called_once_with(
+            f"https://reservoir-api-qa.4subsea.net/api/timeseries/{self.timeseries_id}/data/days?start=0&end=0"
+        )
+        pd.testing.assert_series_equal(response, response_expected)
+
+    def test_get_with_raise_empty_throws(self):
+        index = np.array([6, 7, 8, 9, 10])
+        values = np.array([6.0, 7.0, 8.0, 9.0, 10.0])
+        self._storage.get.return_value = pd.DataFrame(
+            {"index": index, "values": values}
+        )
+
+        with self.assertRaises(ValueError):
+            with patch.object(self.auth, "get") as mock_get:
+                mock_response = Mock()
+                mock_response.raise_for_status.return_value = None
+                mock_response.json.return_value = {
+                    "Files": [
+                        {
+                            "Index": 0,
+                            "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                            "Chunks": [
+                                {
+                                    "Account": "permanentprodu003p144",
+                                    "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                                    "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                                    "Container": "data",
+                                    "Path": "segment_0.csv",
+                                    "Endpoint": "https://go-here-for-blob.com/segment_0",
+                                    "ContentMd5": "md5_0",
+                                    "VersionId": "2021-08-31T13:53:27.3874185Z",
+                                    "DaysSinceEpoch": 0,
+                                },
+                            ],
+                        }
+                    ]
+                }
                 mock_get.return_value = mock_response
 
                 self.client.get(
@@ -606,24 +624,26 @@ class Test_Client(unittest.TestCase):
             mock_response = Mock()
             mock_response.raise_for_status.return_value = None
             mock_response.json.return_value = {
-                "Files": [{
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 0,
-                        },
-                    ],
-                }]
-                }
+                "Files": [
+                    {
+                        "Index": 0,
+                        "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                        "Chunks": [
+                            {
+                                "Account": "permanentprodu003p144",
+                                "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                                "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                                "Container": "data",
+                                "Path": "segment_0.csv",
+                                "Endpoint": "https://go-here-for-blob.com/segment_0",
+                                "ContentMd5": "md5_0",
+                                "VersionId": "2021-08-31T13:53:27.3874185Z",
+                                "DaysSinceEpoch": 0,
+                            },
+                        ],
+                    }
+                ]
+            }
             mock_get.return_value = mock_response
             self.client.get(
                 self.timeseries_id,
@@ -632,7 +652,8 @@ class Test_Client(unittest.TestCase):
             )
 
         self.client._storage.get.assert_called_once_with(
-            "https://reservoir-api-qa.4subsea.net/api/timeseries/abc-123-xyz/data/days?start=0&end=0")
+            "https://reservoir-api-qa.4subsea.net/api/timeseries/abc-123-xyz/data/days?start=0&end=0"
+        )
 
     def test_search(self):
         self.client.search("test_namespace", "test_key", "test_name", 123)
@@ -794,54 +815,54 @@ class Test_TimeSeriesClient_verify_prep_series(unittest.TestCase):
 
 def test__timeseries_available_days():
     response_json = {
-            "Files": [
-                {
-                    "Index": 0,
-                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_0.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_0",
-                            "ContentMd5": "md5_0",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 18806,
-                        },
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_1.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_1",
-                            "ContentMd5": "md5_1",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 18807,
-                        }
-                    ],
-                },
-                {
-                    "Index": 1,
-                    "FileId": "51745116-e25d-4e9c-b7ea-5d7ae4ab004b",
-                    "Chunks": [
-                        {
-                            "Account": "permanentprodu003p144",
-                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
-                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
-                            "Container": "data",
-                            "Path": "segment_3.csv",
-                            "Endpoint": "https://go-here-for-blob.com/segment_3",
-                            "ContentMd5": "md5_3",
-                            "VersionId": "2021-08-31T13:53:27.3874185Z",
-                            "DaysSinceEpoch": 18807,
-                        }
-                    ],
-                }
-            ]
-        }
+        "Files": [
+            {
+                "Index": 0,
+                "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                "Chunks": [
+                    {
+                        "Account": "permanentprodu003p144",
+                        "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                        "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                        "Container": "data",
+                        "Path": "segment_0.csv",
+                        "Endpoint": "https://go-here-for-blob.com/segment_0",
+                        "ContentMd5": "md5_0",
+                        "VersionId": "2021-08-31T13:53:27.3874185Z",
+                        "DaysSinceEpoch": 18806,
+                    },
+                    {
+                        "Account": "permanentprodu003p144",
+                        "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                        "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                        "Container": "data",
+                        "Path": "segment_1.csv",
+                        "Endpoint": "https://go-here-for-blob.com/segment_1",
+                        "ContentMd5": "md5_1",
+                        "VersionId": "2021-08-31T13:53:27.3874185Z",
+                        "DaysSinceEpoch": 18807,
+                    },
+                ],
+            },
+            {
+                "Index": 1,
+                "FileId": "51745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                "Chunks": [
+                    {
+                        "Account": "permanentprodu003p144",
+                        "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                        "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                        "Container": "data",
+                        "Path": "segment_3.csv",
+                        "Endpoint": "https://go-here-for-blob.com/segment_3",
+                        "ContentMd5": "md5_3",
+                        "VersionId": "2021-08-31T13:53:27.3874185Z",
+                        "DaysSinceEpoch": 18807,
+                    }
+                ],
+            },
+        ]
+    }
 
     expected_output = [18806 * 86400000000000, 18807 * 86400000000000]
     output = _timeseries_available_days(response_json)

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 
 from datareservoirio.appdirs import user_cache_dir
-from datareservoirio.storage import BaseDownloader, Storage, StorageCache
+from datareservoirio.storage import Storage, StorageCache
 from datareservoirio.storage.storage import (
     _blob_to_df,
     _df_to_blob,
@@ -141,28 +141,43 @@ def bytesio_with_memory():
 class Test_Storage(unittest.TestCase):
     def setUp(self):
         self._timeseries_api = Mock()
-        self.session = Mock()
+        self.session = MagicMock()
 
         self.tid = "abc-123-xyz"
 
-        self._timeseries_api.download_days.return_value = {
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
             "Files": [
                 {
+                    "Index": 0,
+                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
                     "Chunks": [
-                        {"Endpoint": "https:://go-here-for-blob.com/segment_0"},
-                    ]
-                },
+                        {
+                            "Account": "permanentprodu003p144",
+                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                            "Container": "data",
+                            "Path": "61745116e25d4e9cb7ea5d7ae4ab004b/2021/06/28/day/csv/18806.csv",
+                            "Endpoint": "https:://go-here-for-blob.com/segment_0",
+                            "ContentMd5": "1J+DJHBbx2Kgq9S8WnsV3A==",
+                            "VersionId": "2021-08-31T13:53:27.3874185Z",
+                            "DaysSinceEpoch": 18806,
+                        }
+                    ],
+                }
             ]
         }
+        self.session.request.return_value = mock_response
 
-        self.storage = Storage(self._timeseries_api, session=self.session, cache=False)
+        self.storage = Storage(session=self.session, cache=False)
 
     @patch("datareservoirio.storage.storage._blob_to_df")
     def test_get(self, mock_remote_get):
         data_remote = pd.DataFrame({"index": [1, 2, 3, 4], "values": [1, 2, 3, 4]})
         mock_remote_get.return_value = data_remote.copy()  # Inplace manipulation occurs
 
-        data_out = self.storage.get(self.tid, 2, 3)
+        data_out = self.storage.get("https://myapi/data/days?start=1&end=2")
 
         mock_remote_get.assert_called_once_with(
             "https:://go-here-for-blob.com/segment_0"
@@ -186,223 +201,283 @@ class Test_Storage(unittest.TestCase):
             *commit_request[:2], **commit_request[-1]
         )
 
-
-class Test_BaseDownloader(unittest.TestCase):
-    def test_init(self):
-        BaseDownloader()
-
-    @patch("datareservoirio.storage.storage._blob_to_df")
-    def test_get(self, mock_remote_get):
-        response = {
+    def test__days_response_url_sequence(self):
+        response_json = {
             "Files": [
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]},
+                {
+                    "Index": 0,
+                    "FileId": "61745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                    "Chunks": [
+                        {
+                            "Account": "permanentprodu003p144",
+                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                            "Container": "data",
+                            "Path": "segment_0.csv",
+                            "Endpoint": "https://go-here-for-blob.com/segment_0",
+                            "ContentMd5": "md5_0",
+                            "VersionId": "2021-08-31T13:53:27.3874185Z",
+                            "DaysSinceEpoch": 18806,
+                        },
+                        {
+                            "Account": "permanentprodu003p144",
+                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                            "Container": "data",
+                            "Path": "segment_1.csv",
+                            "Endpoint": "https://go-here-for-blob.com/segment_1",
+                            "ContentMd5": "md5_1",
+                            "VersionId": "2021-08-31T13:53:27.3874185Z",
+                            "DaysSinceEpoch": 18807,
+                        }
+                    ],
+                },
+                {
+                    "Index": 1,
+                    "FileId": "51745116-e25d-4e9c-b7ea-5d7ae4ab004b",
+                    "Chunks": [
+                        {
+                            "Account": "permanentprodu003p144",
+                            "SasKey": "skoid=4b73ab81-cb6b-4de8-934e-cf62e1cc3aa2&sktid=cdf4cf3d-de23-49cf-a9b0-abd2b675f253&skt=2023-02-21T08%3A39%3A13Z&ske=2023-02-22T08%3A39%3A13Z&sks=b&skv=2021-10-04&sv=2021-10-04&spr=https&se=2023-02-21T14%3A34%3A50Z&sr=b&sp=r&sig=3uHDX4JkocmafBv3ZslIR8xkv4x0q2zaNjCcWfw71eI%3D",
+                            "SasKeyExpirationTime": "2023-02-21T14:34:50.8860219+00:00",
+                            "Container": "data",
+                            "Path": "segment_3.csv",
+                            "Endpoint": "https://go-here-for-blob.com/segment_3",
+                            "ContentMd5": "md5_3",
+                            "VersionId": "2021-08-31T13:53:27.3874185Z",
+                            "DaysSinceEpoch": 18807,
+                        }
+                    ],
+                }
             ]
         }
 
-        mock_remote_get.side_effect = [
-            pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}),
-            pd.DataFrame({"index": [3, 4, 5], "values": [5.0, 4.0, 5.0]}),
-            pd.DataFrame({"index": [1, 5, 9], "values": [9.0, 8.0, 1.0]}),
+        out_expected = [
+            {"Endpoint": "https://go-here-for-blob.com/segment_0", "Path": "segment_0.csv", "ContentMd5": "md5_0"},
+            {"Endpoint": "https://go-here-for-blob.com/segment_1", "Path": "segment_1.csv",  "ContentMd5": "md5_1"},
+            {"Endpoint": "https://go-here-for-blob.com/segment_3", "Path": "segment_3.csv", "ContentMd5": "md5_3"}
         ]
 
-        df_expected = pd.DataFrame(
-            {"index": [1, 2, 3, 4, 5, 9], "values": [9.0, 2.0, 5.0, 4.0, 8.0, 1.0]}
-        )
+        out = self.storage._days_response_url_sequence(response_json)
+        assert out == out_expected
 
-        base_downloader = BaseDownloader()
 
-        df_out = base_downloader.get(response)
+# class Test_BaseDownloader(unittest.TestCase):
+#     def test_init(self):
+#         BaseDownloader()
 
-        pd.testing.assert_frame_equal(df_expected, df_out)
+#     @patch("datareservoirio.storage.storage._blob_to_df")
+#     def test_get(self, mock_remote_get):
+#         response = {
+#             "Files": [
+#                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
+#                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
+#                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]},
+#             ]
+#         }
 
-        calls = [
-            call("https:://go-here-for-blob.com/segment_0"),
-            call("https:://go-here-for-blob.com/segment_1"),
-            call("https:://go-here-for-blob.com/segment_2"),
-        ]
-        mock_remote_get.assert_has_calls(calls)
+#         mock_remote_get.side_effect = [
+#             pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}),
+#             pd.DataFrame({"index": [3, 4, 5], "values": [5.0, 4.0, 5.0]}),
+#             pd.DataFrame({"index": [1, 5, 9], "values": [9.0, 8.0, 1.0]}),
+#         ]
 
-    @patch("datareservoirio.storage.storage._blob_to_df")
-    def test_get_with_text_data(self, mock_remote_get):
-        response = {
-            "Files": [
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
-                {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]},
-            ]
-        }
+#         df_expected = pd.DataFrame(
+#             {"index": [1, 2, 3, 4, 5, 9], "values": [9.0, 2.0, 5.0, 4.0, 8.0, 1.0]}
+#         )
 
-        mock_remote_get.side_effect = [
-            pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}),
-            pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}),
-            pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}),
-        ]
+#         base_downloader = BaseDownloader()
 
-        df_expected = pd.DataFrame(
-            {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
-        )
+#         df_out = base_downloader.get(response)
 
-        base_downloader = BaseDownloader()
+#         pd.testing.assert_frame_equal(df_expected, df_out)
 
-        df_out = base_downloader.get(response)
+#         calls = [
+#             call("https:://go-here-for-blob.com/segment_0"),
+#             call("https:://go-here-for-blob.com/segment_1"),
+#             call("https:://go-here-for-blob.com/segment_2"),
+#         ]
+#         mock_remote_get.assert_has_calls(calls)
 
-        pd.testing.assert_frame_equal(df_expected, df_out)
+#     @patch("datareservoirio.storage.storage._blob_to_df")
+#     def test_get_with_text_data(self, mock_remote_get):
+#         response = {
+#             "Files": [
+#                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]},
+#                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_1"}]},
+#                 {"Chunks": [{"Endpoint": "https:://go-here-for-blob.com/segment_2"}]},
+#             ]
+#         }
 
-        calls = [
-            call("https:://go-here-for-blob.com/segment_0"),
-            call("https:://go-here-for-blob.com/segment_1"),
-            call("https:://go-here-for-blob.com/segment_2"),
-        ]
-        mock_remote_get.assert_has_calls(calls)
+#         mock_remote_get.side_effect = [
+#             pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}),
+#             pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}),
+#             pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}),
+#         ]
 
-        # mock_backend = MagicMock()
-        # base_downloader = BaseDownloader(mock_backend)
+#         df_expected = pd.DataFrame(
+#             {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
+#         )
 
-        # response = {
-        #     "Files": [{"Chunks": "abc1"}, {"Chunks": "abc2"}, {"Chunks": "abc3"}]
-        # }
+#         base_downloader = BaseDownloader()
 
-        # with patch.object(
-        #     base_downloader, "_download_chunks_as_dataframe"
-        # ) as mock_download:
-        #     mock_download.side_effect = [
-        #         pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}).set_index(
-        #             "index"
-        #         ),
-        #         pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}).set_index(
-        #             "index"
-        #         ),
-        #         pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}).set_index(
-        #             "index"
-        #         ),
-        #     ]
+#         df_out = base_downloader.get(response)
 
-        #     df_expected = pd.DataFrame(
-        #         {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
-        #     )
-        #     df_out = base_downloader.get(response)
+#         pd.testing.assert_frame_equal(df_expected, df_out)
 
-        # pd.testing.assert_frame_equal(df_expected, df_out)
+#         calls = [
+#             call("https:://go-here-for-blob.com/segment_0"),
+#             call("https:://go-here-for-blob.com/segment_1"),
+#             call("https:://go-here-for-blob.com/segment_2"),
+#         ]
+#         mock_remote_get.assert_has_calls(calls)
 
-    def test_get_empty(self):
-        mock_backend = MagicMock()
-        base_downloader = BaseDownloader(mock_backend)
+#         # mock_backend = MagicMock()
+#         # base_downloader = BaseDownloader(mock_backend)
 
-        response = {"Files": []}
+#         # response = {
+#         #     "Files": [{"Chunks": "abc1"}, {"Chunks": "abc2"}, {"Chunks": "abc3"}]
+#         # }
 
-        df_out = base_downloader.get(response)
+#         # with patch.object(
+#         #     base_downloader, "_download_chunks_as_dataframe"
+#         # ) as mock_download:
+#         #     mock_download.side_effect = [
+#         #         pd.DataFrame({"index": [1, 2, 3], "values": ["a", "b", "c"]}).set_index(
+#         #             "index"
+#         #         ),
+#         #         pd.DataFrame({"index": [3, 4, 5], "values": ["d", "e", "f"]}).set_index(
+#         #             "index"
+#         #         ),
+#         #         pd.DataFrame({"index": [1, 5, 9], "values": ["g", "h", "i"]}).set_index(
+#         #             "index"
+#         #         ),
+#         #     ]
 
-        df_expected = pd.DataFrame(
-            pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
-        )
+#         #     df_expected = pd.DataFrame(
+#         #         {"index": [1, 2, 3, 4, 5, 9], "values": ["g", "b", "d", "e", "h", "i"]}
+#         #     )
+#         #     df_out = base_downloader.get(response)
 
-        mock_backend.assert_not_called()
-        pd.testing.assert_frame_equal(df_expected, df_out)
+#         # pd.testing.assert_frame_equal(df_expected, df_out)
 
-    def test__combine_first_no_overlap(self):
-        df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
-        df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[6, 7, 8, 9])
-        df_expected = df1.combine_first(df2)
-        df_out = BaseDownloader._combine_first(df1, df2)
-        pd.testing.assert_series_equal(df_expected, df_out)
+#     def test_get_empty(self):
+#         mock_backend = MagicMock()
+#         base_downloader = BaseDownloader(mock_backend)
 
-    def test__combine_first_no_overlap_reversed_order(self):
-        df2 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
-        df1 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[6, 7, 8, 9])
-        df_expected = df1.combine_first(df2)
-        df_out = BaseDownloader._combine_first(df1, df2)
-        pd.testing.assert_series_equal(df_expected, df_out)
+#         response = {"Files": []}
 
-    def test__combine_first_exact_overlap(self):
-        df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
-        df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[0, 1, 2, 3])
-        df_expected = df1.combine_first(df2)
-        df_out = BaseDownloader._combine_first(df1, df2)
-        pd.testing.assert_series_equal(df_expected, df_out)
+#         df_out = base_downloader.get(response)
 
-    def test__combine_first_partial_overlap(self):
-        df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
-        df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[2, 3, 4, 5])
-        df_expected = df1.combine_first(df2)
-        df_out = BaseDownloader._combine_first(df1, df2)
-        pd.testing.assert_series_equal(df_expected, df_out)
+#         df_expected = pd.DataFrame(
+#             pd.DataFrame(columns=("index", "values")).astype({"index": "int64"})
+#         )
 
-    @patch("datareservoirio.storage.storage._blob_to_df")
-    def test__download_verified_chunk(self, mock_remote_get):
-        chunk = {"Endpoint": "https:://go-here-for-blob.com/segment_0"}
+#         mock_backend.assert_not_called()
+#         pd.testing.assert_frame_equal(df_expected, df_out)
 
-        mock_remote_get.side_effect = [
-            pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
-        ]
+#     def test__combine_first_no_overlap(self):
+#         df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
+#         df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[6, 7, 8, 9])
+#         df_expected = df1.combine_first(df2)
+#         df_out = BaseDownloader._combine_first(df1, df2)
+#         pd.testing.assert_series_equal(df_expected, df_out)
 
-        df_expected = pd.DataFrame(
-            {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
-        ).set_index("index")
+#     def test__combine_first_no_overlap_reversed_order(self):
+#         df2 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
+#         df1 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[6, 7, 8, 9])
+#         df_expected = df1.combine_first(df2)
+#         df_out = BaseDownloader._combine_first(df1, df2)
+#         pd.testing.assert_series_equal(df_expected, df_out)
 
-        base_downloader = BaseDownloader()
+#     def test__combine_first_exact_overlap(self):
+#         df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
+#         df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[0, 1, 2, 3])
+#         df_expected = df1.combine_first(df2)
+#         df_out = BaseDownloader._combine_first(df1, df2)
+#         pd.testing.assert_series_equal(df_expected, df_out)
 
-        df_out = base_downloader._download_verified_chunk(chunk)
-        mock_remote_get.assert_called_once_with(chunk["Endpoint"])
+#     def test__combine_first_partial_overlap(self):
+#         df1 = pd.Series([0.0, 1.0, 2.0, 3.0], index=[0, 1, 2, 3])
+#         df2 = pd.Series([10.0, 11.0, 12.0, 13.0], index=[2, 3, 4, 5])
+#         df_expected = df1.combine_first(df2)
+#         df_out = BaseDownloader._combine_first(df1, df2)
+#         pd.testing.assert_series_equal(df_expected, df_out)
 
-        pd.testing.assert_frame_equal(df_expected, df_out)
+#     @patch("datareservoirio.storage.storage._blob_to_df")
+#     def test__download_verified_chunk(self, mock_remote_get):
+#         chunk = {"Endpoint": "https:://go-here-for-blob.com/segment_0"}
 
-    @patch("datareservoirio.storage.storage._blob_to_df")
-    def test__download_verified_chunk_w_duplicates(self, mock_remote_get):
-        chunk = {"Endpoint": "https:://go-here-for-blob.com/segment_0"}
+#         mock_remote_get.side_effect = [
+#             pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
+#         ]
 
-        mock_remote_get.side_effect = [
-            pd.DataFrame({"index": [1, 2, 2, 3], "values": [1.0, 2.0, 2.0, 3.0]})
-        ]
+#         df_expected = pd.DataFrame(
+#             {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
+#         ).set_index("index")
 
-        df_expected = pd.DataFrame(
-            {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
-        ).set_index("index")
+#         base_downloader = BaseDownloader()
 
-        base_downloader = BaseDownloader()
+#         df_out = base_downloader._download_verified_chunk(chunk)
+#         mock_remote_get.assert_called_once_with(chunk["Endpoint"])
 
-        df_out = base_downloader._download_verified_chunk(chunk)
-        mock_remote_get.assert_called_once_with(chunk["Endpoint"])
+#         pd.testing.assert_frame_equal(df_expected, df_out)
 
-        pd.testing.assert_frame_equal(df_expected, df_out)
+#     @patch("datareservoirio.storage.storage._blob_to_df")
+#     def test__download_verified_chunk_w_duplicates(self, mock_remote_get):
+#         chunk = {"Endpoint": "https:://go-here-for-blob.com/segment_0"}
 
-    @patch("datareservoirio.storage.storage._blob_to_df")
-    def test__download_chunks_as_dataframe(self, mock_remote_get):
-        chunk = [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]
-        mock_remote_get.side_effect = [
-            pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
-        ]
+#         mock_remote_get.side_effect = [
+#             pd.DataFrame({"index": [1, 2, 2, 3], "values": [1.0, 2.0, 2.0, 3.0]})
+#         ]
 
-        df_expected = pd.DataFrame(
-            {
-                "index": [1, 2, 3],
-                "values": [1.0, 2.0, 3.0],
-            }
-        ).set_index("index")
+#         df_expected = pd.DataFrame(
+#             {"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]}
+#         ).set_index("index")
 
-        base_downloader = BaseDownloader()
-        df_out = base_downloader._download_chunks_as_dataframe(chunk)
+#         base_downloader = BaseDownloader()
 
-        mock_remote_get.assert_called_once_with(
-            "https:://go-here-for-blob.com/segment_0"
-        )
-        pd.testing.assert_frame_equal(df_expected, df_out)
+#         df_out = base_downloader._download_verified_chunk(chunk)
+#         mock_remote_get.assert_called_once_with(chunk["Endpoint"])
 
-    def test__download_chunks_as_dataframe_no_chunks(self):
-        mock_backend = MagicMock()
+#         pd.testing.assert_frame_equal(df_expected, df_out)
 
-        base_downloader = BaseDownloader(mock_backend)
-        df_out = base_downloader._download_chunks_as_dataframe([])
+#     @patch("datareservoirio.storage.storage._blob_to_df")
+#     def test__download_chunks_as_dataframe(self, mock_remote_get):
+#         chunk = [{"Endpoint": "https:://go-here-for-blob.com/segment_0"}]
+#         mock_remote_get.side_effect = [
+#             pd.DataFrame({"index": [1, 2, 3], "values": [1.0, 2.0, 3.0]})
+#         ]
 
-        df_expected = (
-            pd.DataFrame(columns=("index", "values"))
-            .astype({"index": "int64"})
-            .set_index("index")
-        )
+#         df_expected = pd.DataFrame(
+#             {
+#                 "index": [1, 2, 3],
+#                 "values": [1.0, 2.0, 3.0],
+#             }
+#         ).set_index("index")
 
-        mock_backend.assert_not_called()
-        pd.testing.assert_frame_equal(df_expected, df_out)
+#         base_downloader = BaseDownloader()
+#         df_out = base_downloader._download_chunks_as_dataframe(chunk)
+
+#         mock_remote_get.assert_called_once_with(
+#             "https:://go-here-for-blob.com/segment_0"
+#         )
+#         pd.testing.assert_frame_equal(df_expected, df_out)
+
+#     def test__download_chunks_as_dataframe_no_chunks(self):
+#         mock_backend = MagicMock()
+
+#         base_downloader = BaseDownloader(mock_backend)
+#         df_out = base_downloader._download_chunks_as_dataframe([])
+
+#         df_expected = (
+#             pd.DataFrame(columns=("index", "values"))
+#             .astype({"index": "int64"})
+#             .set_index("index")
+#         )
+
+#         mock_backend.assert_not_called()
+#         pd.testing.assert_frame_equal(df_expected, df_out)
 
 
 class Test_StorageCache(unittest.TestCase):

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -168,7 +168,7 @@ class Test_Storage(unittest.TestCase):
                 }
             ]
         }
-        self.session.request.return_value = mock_response
+        self.session.get.return_value = mock_response
 
         self.storage = Storage(session=self.session, cache=False)
 

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -229,7 +229,7 @@ class Test_Storage(unittest.TestCase):
                             "ContentMd5": "md5_1",
                             "VersionId": "2021-08-31T13:53:27.3874185Z",
                             "DaysSinceEpoch": 18807,
-                        }
+                        },
                     ],
                 },
                 {
@@ -248,14 +248,26 @@ class Test_Storage(unittest.TestCase):
                             "DaysSinceEpoch": 18807,
                         }
                     ],
-                }
+                },
             ]
         }
 
         out_expected = [
-            {"Endpoint": "https://go-here-for-blob.com/segment_0", "Path": "segment_0.csv", "ContentMd5": "md5_0"},
-            {"Endpoint": "https://go-here-for-blob.com/segment_1", "Path": "segment_1.csv",  "ContentMd5": "md5_1"},
-            {"Endpoint": "https://go-here-for-blob.com/segment_3", "Path": "segment_3.csv", "ContentMd5": "md5_3"}
+            {
+                "Endpoint": "https://go-here-for-blob.com/segment_0",
+                "Path": "segment_0.csv",
+                "ContentMd5": "md5_0",
+            },
+            {
+                "Endpoint": "https://go-here-for-blob.com/segment_1",
+                "Path": "segment_1.csv",
+                "ContentMd5": "md5_1",
+            },
+            {
+                "Endpoint": "https://go-here-for-blob.com/segment_3",
+                "Path": "segment_3.csv",
+                "ContentMd5": "md5_3",
+            },
         ]
 
         out = self.storage._days_response_url_sequence(response_json)


### PR DESCRIPTION
### This PR is related to user story DST-253

## Description
This is the final PR addressing the original issue: SAS-key expiry when downloading large/long timeseries. As an added benefit, concurrency is much improved with significant download performance boost!

What has changed:

- Refactor `Storage.get`. Now it accepts a URL (and downloads blobs in sequence and merges). Optimal use is when URL only points to a single day!
- `Storage.get` is much simpler! `BaseDownloader` is gone! Concurrency is moved out to `Client.get`.
- Refactor `Client.get`. It figures out which days are available as data covered by the `start` and `end` range, and makes calls to `Storage.get` accordingly. Multi-threading is applied here for significant perf boost.

As before, unit tests are no good, so test it HARD!

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

