### PR TITLE
BUGFIX - start and end date should be json serializable

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -250,11 +250,13 @@ class Client:
             result = func(self, series_id, start=start, end=end, **kwargs)
             end_time = time.perf_counter()
             elapsed_time = end_time - start_time
+            start_date_as_str = pd.to_datetime(start, dayfirst=True, unit="ns", utc=True).strftime("%Y-%m-%DT%H:%M:%S.%f%z")
+            end_date_as_str = pd.to_datetime(end, dayfirst=True, unit="ns", utc=True).strftime("%Y-%m-%DT%H:%M:%S.%f%z")
             properties = {
                 "custom_dimensions": {
                     "series_id": series_id,
-                    "start": start,
-                    "end": end,
+                    "start": start_date_as_str,
+                    "end": end_date_as_str,
                     "elapsed": elapsed_time,
                 }
             }


### PR DESCRIPTION
### This PR is related to user story DST-448

## Description
Start and end time received by timer decorator are now formatted, in order to make sure they are json serializable and can be logged.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

