### PR TITLE
test: Add integration test that can create/append/delete timeseries with numeric data

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,0 +1,17 @@
+# Integration tests for datareservoirio
+
+## How to use?
+In order to run the integration tests, you must first set the ``DRIO_CLIENT_ID`` and ``DRIO_CLIENT_SECRET``
+environment variables. This can be done with the following commands in the CMD prompt window (note that these GUIDs are only for demonstration purposes):
+
+```console
+set DRIO_CLIENT_ID=63b8d619-84ac-456d-8a76-bb8fd889e04c
+set DRIO_CLIENT_SECRET=63b8d619-84ac-456d-8a76-bb8fd889e04c
+```
+
+After having set the environment variables, you can run the integration tests with ``pytest``:
+
+```console
+pytest integration_tests
+```
+

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -5,12 +5,13 @@ import datareservoirio as drio
 
 @pytest.fixture
 def series_created():
+    """List of created timeseries IDs"""
     return set()
 
 
 @pytest.fixture
-def store_created(monkeypatch, series_created):
-
+def store_created_series(monkeypatch, series_created):
+    """Store created timeseries IDs to the ``series_created`` list"""
     class ClientStoreCreated(drio.Client):
         def create(self, *args, **kwargs):
             return_value = super().create(*args, **kwargs)
@@ -29,12 +30,13 @@ def auth_session():
 
 
 @pytest.fixture
-def client(auth_session, store_created, series_created):
+def client(auth_session, store_created_series, series_created):
 
     client = drio.Client(auth_session)
 
     yield client
 
+    # Delete all created timeseries from DataReservoir.io
     while series_created:
         series_id_i = series_created.pop()
         try:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,5 +1,8 @@
+import os
+
 import pytest
 from requests import HTTPError
+
 import datareservoirio as drio
 
 
@@ -12,6 +15,7 @@ def series_created():
 @pytest.fixture
 def store_created_series(monkeypatch, series_created):
     """Store created timeseries IDs to the ``series_created`` list"""
+
     class ClientStoreCreated(drio.Client):
         def create(self, *args, **kwargs):
             return_value = super().create(*args, **kwargs)
@@ -24,14 +28,13 @@ def store_created_series(monkeypatch, series_created):
 
 @pytest.fixture
 def auth_session():
-    client_id = "0ee5d1b4-2271-4595-8c23-f2361d713a47"
-    client_secret = "2iF8Q~t_WniDYJmFnM8cjB6KoBGH-2C9Imij9cKa"
+    client_id = os.getenv("DRIO_CLIENT_ID")
+    client_secret = os.getenv("DRIO_CLIENT_SECRET")
     return drio.authenticate.ClientAuthenticator(client_id, client_secret)
 
 
 @pytest.fixture
 def client(auth_session, store_created_series, series_created):
-
     client = drio.Client(auth_session)
 
     yield client

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -23,7 +23,6 @@ def client():
 
 @pytest.fixture()
 def cleanup_series(client):
-
     series_created = set()
 
     yield series_created

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -14,7 +14,7 @@ def store_created(monkeypatch, series_created):
     class ClientStoreCreated(drio.Client):
         def create(self, *args, **kwargs):
             return_value = super().create(*args, **kwargs)
-            series_id = kwargs.get("series_id") or args[0]
+            series_id = return_value["TimeSeriesId"]
             series_created.add(series_id)
             return return_value
 
@@ -22,16 +22,22 @@ def store_created(monkeypatch, series_created):
 
 
 @pytest.fixture
-def client(store_created, series_created):
+def auth_session():
     client_id = "0ee5d1b4-2271-4595-8c23-f2361d713a47"
     client_secret = "2iF8Q~t_WniDYJmFnM8cjB6KoBGH-2C9Imij9cKa"
-    client = drio.authenticate.ClientAuthenticator(client_id, client_secret)
+    return drio.authenticate.ClientAuthenticator(client_id, client_secret)
+
+
+@pytest.fixture
+def client(auth_session, store_created, series_created):
+
+    client = drio.Client(auth_session)
+
     yield client
 
-    for series_id_i in series_created:
+    while series_created:
+        series_id_i = series_created.pop()
         try:
             client.delete(series_id_i)
         except HTTPError:
             pass
-        finally:
-            series_created.remove(series_id_i)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+from requests import HTTPError
+import datareservoirio as drio
+
+
+@pytest.fixture
+def series_created():
+    return set()
+
+
+@pytest.fixture
+def store_created(monkeypatch, series_created):
+
+    class ClientStoreCreated(drio.Client):
+        def create(self, *args, **kwargs):
+            return_value = super().create(*args, **kwargs)
+            series_id = kwargs.get("series_id") or args[0]
+            series_created.add(series_id)
+            return return_value
+
+    monkeypatch.setattr("datareservoirio.Client", ClientStoreCreated)
+
+
+@pytest.fixture
+def client(store_created, series_created):
+    client_id = "0ee5d1b4-2271-4595-8c23-f2361d713a47"
+    client_secret = "2iF8Q~t_WniDYJmFnM8cjB6KoBGH-2C9Imij9cKa"
+    client = drio.authenticate.ClientAuthenticator(client_id, client_secret)
+    yield client
+
+    for series_id_i in series_created:
+        try:
+            client.delete(series_id_i)
+        except HTTPError:
+            pass
+        finally:
+            series_created.remove(series_id_i)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -19,8 +19,7 @@ def store_created_series(monkeypatch, series_created):
     class ClientStoreCreated(drio.Client):
         def create(self, *args, **kwargs):
             return_value = super().create(*args, **kwargs)
-            series_id = return_value["TimeSeriesId"]
-            series_created.add(series_id)
+            series_created.add(return_value["TimeSeriesId"])
             return return_value
 
     monkeypatch.setattr("datareservoirio.Client", ClientStoreCreated)
@@ -39,7 +38,7 @@ def client(auth_session, store_created_series, series_created):
 
     yield client
 
-    # Delete all created timeseries from DataReservoir.io
+    # Delete all created timeseries from DataReservoir.io (if not already deleted)
     while series_created:
         series_id_i = series_created.pop()
         try:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -14,10 +14,15 @@ def set_environment_qa():
 
 
 @pytest.fixture(scope="session")
-def client():
+def auth_session():
     client_id = os.getenv("DRIO_CLIENT_ID")
     client_secret = os.getenv("DRIO_CLIENT_SECRET")
     auth_session = drio.authenticate.ClientAuthenticator(client_id, client_secret)
+    return auth_session
+
+
+@pytest.fixture()
+def client(auth_session):
     return drio.Client(auth_session)
 
 

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -13,37 +13,24 @@ def set_environment_qa():
     env.set_qa()
 
 
-@pytest.fixture
-def store_created_series(monkeypatch):
-    """Store created timeseries IDs"""
-
-    class ClientStoreCreated(drio.Client):
-        _series_created = set()
-
-        def create(self, *args, **kwargs):
-            return_value = super().create(*args, **kwargs)
-            self._series_created.add(return_value["TimeSeriesId"])
-            return return_value
-
-    monkeypatch.setattr("datareservoirio.Client", ClientStoreCreated)
-
-
-@pytest.fixture
-def auth_session():
+@pytest.fixture(scope="session")
+def client():
     client_id = os.getenv("DRIO_CLIENT_ID")
     client_secret = os.getenv("DRIO_CLIENT_SECRET")
-    return drio.authenticate.ClientAuthenticator(client_id, client_secret)
+    auth_session = drio.authenticate.ClientAuthenticator(client_id, client_secret)
+    return drio.Client(auth_session)
 
 
-@pytest.fixture
-def client(auth_session, store_created_series):
-    client = drio.Client(auth_session)
+@pytest.fixture()
+def cleanup_series(client):
 
-    yield client
+    series_created = set()
+
+    yield series_created
 
     # Delete all created timeseries from DataReservoir.io (if not already deleted)
-    while client._series_created:
-        series_id_i = client._series_created.pop()
+    while series_created:
+        series_id_i = series_created.pop()
         try:
             client.delete(series_id_i)
         except HTTPError:

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -23,20 +23,18 @@ def test_numeric_datetime(client):
     start_a = "2022-12-28 00:00"
     end_a = "2023-01-02 00:00"
     freq_a = pd.to_timedelta(0.1, "s")
-    timestamps_a = pd.date_range(
-        start_a, end_a, freq=freq_a, tz="utc", inclusive="left"
+    index_a = pd.date_range(start_a, end_a, freq=freq_a, tz="utc", inclusive="left")
+    series_a = pd.Series(
+        data=np.random.random(len(index_a)), index=index_a, name="values"
     )
-    values_a = np.random.random(len(timestamps_a))
-    series_a = pd.Series(data=values_a, index=timestamps_a, name="values")
 
     start_b = "2023-01-02 00:00"
     end_b = "2023-01-02 03:00"
     freq_b = pd.to_timedelta(0.1, "s")
-    timestamps_b = pd.date_range(
-        start_b, end_b, freq=freq_b, tz="utc", inclusive="left"
+    index_b = pd.date_range(start_b, end_b, freq=freq_b, tz="utc", inclusive="left")
+    series_b = pd.Series(
+        data=np.random.random(len(index_b)), index=index_b, name="values"
     )
-    values_b = np.random.random(len(timestamps_b))
-    series_b = pd.Series(data=values_b, index=timestamps_b, name="values")
 
     series_a_and_b = pd.concat([series_a, series_b])
 
@@ -48,7 +46,9 @@ def test_numeric_datetime(client):
     series_full_before_append = client.get(series_id, start=None, end=None)
 
     # Check downloaded data
-    pd.testing.assert_series_equal(series_a, series_full_before_append, check_freq=False)
+    pd.testing.assert_series_equal(
+        series_a, series_full_before_append, check_freq=False
+    )
 
     # Append more data to the timeseries
     _ = client.append(series_b, series_id, wait_on_verification=True)
@@ -57,7 +57,9 @@ def test_numeric_datetime(client):
     series_full_after_append = client.get(series_id, start=None, end=None)
 
     # Check downloaded data
-    pd.testing.assert_series_equal(series_a_and_b, series_full_after_append, check_freq=False)
+    pd.testing.assert_series_equal(
+        series_a_and_b, series_full_after_append, check_freq=False
+    )
 
     # Delete timeseries from DataReservoi.io
     client.delete(series_id)

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -27,7 +27,7 @@ def test_numeric_datetime(cleanup_series):
     client = drio.Client(auth_session)
 
     # Create some dummy data
-    start_a = "2022-12-28 00:00"
+    start_a = "2022-12-30 00:00"
     end_a = "2023-01-02 00:00"
     freq_a = pd.to_timedelta(0.1, "s")
     index_a = pd.date_range(start_a, end_a, freq=freq_a, tz="utc", inclusive="left")

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+import pytest
+from requests import HTTPError
 
 import datareservoirio as drio
 
@@ -64,3 +66,7 @@ def test_numeric_datetime(client):
 
     # Delete timeseries from DataReservoir.io
     client.delete(series_id)
+
+    # Check that the timeseries is deleted
+    with pytest.raises(HTTPError):
+        _ = client.get(series_id)

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -1,0 +1,14 @@
+"""
+Integration test.
+
+Tests the following:
+    * Create timeseries in DataReservoir.io.
+    * Append more data to the created timeseries.
+    * Delete the timeseries from DataReservoi.io
+
+"""
+import datareservoirio as drio
+
+
+def test_numeric_datetime(client):
+    assert 1 == 1

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -3,8 +3,6 @@ import pandas as pd
 import pytest
 from requests import HTTPError
 
-import datareservoirio as drio
-
 
 def test_numeric_datetime(client):
     """
@@ -17,10 +15,6 @@ def test_numeric_datetime(client):
         * Delete the timeseries from DataReservoir.io
 
     """
-
-    # Set environment to 'TEST'
-    env = drio.environments.Environment()
-    env.set_test()
 
     # Create some dummy data
     start_a = "2022-12-28 00:00"

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -38,7 +38,7 @@ def test_numeric_datetime(client):
 
     series_a_and_b = pd.concat([series_a, series_b])
 
-    # Create and upload timeseries to DataReservoi.io
+    # Create and upload timeseries to DataReservoir.io
     response_create = client.create(series=series_a, wait_on_verification=True)
     series_id = response_create["TimeSeriesId"]
 
@@ -61,5 +61,5 @@ def test_numeric_datetime(client):
         series_a_and_b, series_full_after_append, check_freq=False
     )
 
-    # Delete timeseries from DataReservoi.io
+    # Delete timeseries from DataReservoir.io
     client.delete(series_id)

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -1,13 +1,3 @@
-"""
-Integration test for creating/appending/deleting timeseries with numeric values
-and datetime index.
-
-Tests the following:
-    * Create a timeseries in DataReservoir.io.
-    * Append more data to the created timeseries.
-    * Delete the timeseries from DataReservoir.io
-
-"""
 import numpy as np
 import pandas as pd
 
@@ -15,6 +5,17 @@ import datareservoirio as drio
 
 
 def test_numeric_datetime(client):
+    """
+    Integration test for creating/appending/deleting timeseries with numeric values
+    and datetime index.
+
+    Tests the following:
+        * Create a timeseries in DataReservoir.io.
+        * Append more data to the created timeseries.
+        * Delete the timeseries from DataReservoir.io
+
+    """
+
     # Set environment to 'TEST'
     env = drio.environments.Environment()
     env.set_test()

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -7,8 +7,42 @@ Tests the following:
     * Delete the timeseries from DataReservoi.io
 
 """
+import numpy as np
+import pandas as pd
 import datareservoirio as drio
 
 
 def test_numeric_datetime(client):
-    assert 1 == 1
+
+    # Set environment to 'TEST'
+    # -------------------------
+    env = drio.environments.Environment()
+    env.set_test()
+
+    # Create some dummy data
+    # ----------------------
+
+    # First 'chunk' of data
+    start_a = "2022-12-28 00:00"
+    end_a = "2023-01-02 00:00"
+    freq_a = pd.to_timedelta(0.1, "s")
+
+    timestamps_a = pd.date_range(start_a, end_a, freq=freq_a, tz="utc", inclusive="left")
+    values_a = np.random.random(len(timestamps_a))
+
+    series_a = pd.Series(data=values_a, index=timestamps_a, name="values")
+
+    # Second 'chunk 'of data
+    start_b = "2023-01-02 00:00"
+    end_b = "2023-01-02 03:00"
+    freq_b = pd.to_timedelta(0.1, "s")
+
+    timestamps_b = pd.date_range(start_b, end_b, freq=freq_b, tz="utc", inclusive="left")
+    values_b = np.random.random(len(timestamps_b))
+
+    series_b = pd.Series(data=values_b, index=timestamps_b, name="values")
+
+    # Create and upload timeseries to DRIO
+    # ------------------------------------
+    response_create = client.create(series=series_a, wait_on_verification=True)
+    series_id = response_create["TimeSeriesId"]

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -1,10 +1,13 @@
+import os
 import numpy as np
 import pandas as pd
 import pytest
 from requests import HTTPError
 
+import datareservoirio as drio
 
-def test_numeric_datetime(client):
+
+def test_numeric_datetime(cleanup_series):
     """
     Integration test for creating/appending/deleting timeseries with numeric values
     and datetime index.
@@ -15,6 +18,13 @@ def test_numeric_datetime(client):
         * Delete the timeseries from DataReservoir.io
 
     """
+
+    # Initialize client
+    auth_session = drio.authenticate.ClientAuthenticator(
+        os.getenv("DRIO_CLIENT_ID"),
+        os.getenv("DRIO_CLIENT_SECRET")
+    )
+    client = drio.Client(auth_session)
 
     # Create some dummy data
     start_a = "2022-12-28 00:00"
@@ -38,6 +48,7 @@ def test_numeric_datetime(client):
     # Create and upload timeseries to DataReservoir.io
     response_create = client.create(series=series_a, wait_on_verification=True)
     series_id = response_create["TimeSeriesId"]
+    cleanup_series.add(series_id)
 
     # Get data from DataReservoir.io (before data is appended)
     series_full_before_append = client.get(series_id, start=None, end=None)

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -69,6 +69,17 @@ def test_numeric_datetime(cleanup_series):
         series_a_and_b, series_full_after_append, check_freq=False
     )
 
+    # Get data between two dates from DataReservoir.io
+    start = pd.to_datetime("2023-01-01 00:00", utc=True)
+    end = pd.to_datetime("2023-01-01 03:00", utc=True)
+    delta = pd.to_timedelta(1, "ns")
+    series_partial = client.get(series_id, start=start, end=end)
+
+    # Check downloaded data
+    pd.testing.assert_series_equal(
+        series_a_and_b.loc[start : end - delta], series_partial, check_freq=False
+    )
+
     # Delete timeseries from DataReservoir.io
     client.delete(series_id)
 

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -1,10 +1,10 @@
 """
-Integration test.
+Integration test for numeric data with datetime index.
 
 Tests the following:
     * Create timeseries in DataReservoir.io.
     * Append more data to the created timeseries.
-    * Delete the timeseries from DataReservoi.io
+    * Delete the timeseries from DataReservoir.io
 
 """
 import numpy as np
@@ -15,38 +15,48 @@ import datareservoirio as drio
 
 def test_numeric_datetime(client):
     # Set environment to 'TEST'
-    # -------------------------
     env = drio.environments.Environment()
     env.set_test()
 
     # Create some dummy data
-    # ----------------------
-
-    # First 'chunk' of data
     start_a = "2022-12-28 00:00"
     end_a = "2023-01-02 00:00"
     freq_a = pd.to_timedelta(0.1, "s")
-
     timestamps_a = pd.date_range(
         start_a, end_a, freq=freq_a, tz="utc", inclusive="left"
     )
     values_a = np.random.random(len(timestamps_a))
-
     series_a = pd.Series(data=values_a, index=timestamps_a, name="values")
 
-    # Second 'chunk 'of data
     start_b = "2023-01-02 00:00"
     end_b = "2023-01-02 03:00"
     freq_b = pd.to_timedelta(0.1, "s")
-
     timestamps_b = pd.date_range(
         start_b, end_b, freq=freq_b, tz="utc", inclusive="left"
     )
     values_b = np.random.random(len(timestamps_b))
-
     series_b = pd.Series(data=values_b, index=timestamps_b, name="values")
 
-    # Create and upload timeseries to DRIO
-    # ------------------------------------
+    series_a_and_b = pd.concat([series_a, series_b])
+
+    # Create and upload timeseries to DataReservoi.io
     response_create = client.create(series=series_a, wait_on_verification=True)
     series_id = response_create["TimeSeriesId"]
+
+    # Get data from DataReservoir.io (before data is appended)
+    series_full_before_append = client.get(series_id, start=None, end=None)
+
+    # Check downloaded data
+    pd.testing.assert_series_equal(series_a, series_full_before_append, check_freq=False)
+
+    # Append more data to the timeseries
+    _ = client.append(series_b, series_id, wait_on_verification=True)
+
+    # Get data from DataReservoir.io (after data is appended)
+    series_full_after_append = client.get(series_id, start=None, end=None)
+
+    # Check downloaded data
+    pd.testing.assert_series_equal(series_a_and_b, series_full_after_append, check_freq=False)
+
+    # Delete timeseries from DataReservoi.io
+    client.delete(series_id)

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -1,8 +1,9 @@
 """
-Integration test for numeric data with datetime index.
+Integration test for creating/appending/deleting timeseries with numeric values
+and datetime index.
 
 Tests the following:
-    * Create timeseries in DataReservoir.io.
+    * Create a timeseries in DataReservoir.io.
     * Append more data to the created timeseries.
     * Delete the timeseries from DataReservoir.io
 

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -9,11 +9,11 @@ Tests the following:
 """
 import numpy as np
 import pandas as pd
+
 import datareservoirio as drio
 
 
 def test_numeric_datetime(client):
-
     # Set environment to 'TEST'
     # -------------------------
     env = drio.environments.Environment()
@@ -27,7 +27,9 @@ def test_numeric_datetime(client):
     end_a = "2023-01-02 00:00"
     freq_a = pd.to_timedelta(0.1, "s")
 
-    timestamps_a = pd.date_range(start_a, end_a, freq=freq_a, tz="utc", inclusive="left")
+    timestamps_a = pd.date_range(
+        start_a, end_a, freq=freq_a, tz="utc", inclusive="left"
+    )
     values_a = np.random.random(len(timestamps_a))
 
     series_a = pd.Series(data=values_a, index=timestamps_a, name="values")
@@ -37,7 +39,9 @@ def test_numeric_datetime(client):
     end_b = "2023-01-02 03:00"
     freq_b = pd.to_timedelta(0.1, "s")
 
-    timestamps_b = pd.date_range(start_b, end_b, freq=freq_b, tz="utc", inclusive="left")
+    timestamps_b = pd.date_range(
+        start_b, end_b, freq=freq_b, tz="utc", inclusive="left"
+    )
     values_b = np.random.random(len(timestamps_b))
 
     series_b = pd.Series(data=values_b, index=timestamps_b, name="values")

--- a/integration_tests/test_numeric_datetime.py
+++ b/integration_tests/test_numeric_datetime.py
@@ -1,4 +1,5 @@
 import os
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -21,8 +22,7 @@ def test_numeric_datetime(cleanup_series):
 
     # Initialize client
     auth_session = drio.authenticate.ClientAuthenticator(
-        os.getenv("DRIO_CLIENT_ID"),
-        os.getenv("DRIO_CLIENT_SECRET")
+        os.getenv("DRIO_CLIENT_ID"), os.getenv("DRIO_CLIENT_SECRET")
     )
     client = drio.Client(auth_session)
 


### PR DESCRIPTION
### This PR is related to user story DST-451

## Description
Integration test for creating/appending/deleting timeseries from DataReservoir.io.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

