### PR TITLE
Integration test for creating/downloading empty timeseries

### DIFF
--- a/integration_tests/test_empty.py
+++ b/integration_tests/test_empty.py
@@ -9,13 +9,10 @@ import datareservoirio as drio
 
 def test_empty(cleanup_series):
     """
-    Integration test for creating/appending/deleting timeseries with numeric values
-    and datetime index.
+    Integration test for empty timeseries.
 
     Tests the following:
-        * Create a timeseries in DataReservoir.io.
-        * Append more data to the created timeseries.
-        * Delete the timeseries from DataReservoir.io
+        * Create an empty timeseries in DataReservoir.io.
 
     """
 

--- a/integration_tests/test_empty.py
+++ b/integration_tests/test_empty.py
@@ -1,0 +1,51 @@
+import os
+
+import pandas as pd
+import pytest
+from requests import HTTPError
+
+import datareservoirio as drio
+
+
+def test_empty(cleanup_series):
+    """
+    Integration test for creating/appending/deleting timeseries with numeric values
+    and datetime index.
+
+    Tests the following:
+        * Create a timeseries in DataReservoir.io.
+        * Append more data to the created timeseries.
+        * Delete the timeseries from DataReservoir.io
+
+    """
+
+    # Initialize client
+    auth_session = drio.authenticate.ClientAuthenticator(
+        os.getenv("DRIO_CLIENT_ID"), os.getenv("DRIO_CLIENT_SECRET")
+    )
+    client = drio.Client(auth_session)
+
+    # Create and upload timeseries to DataReservoir.io
+    response_create = client.create(series=None, wait_on_verification=True)
+    series_id = response_create["TimeSeriesId"]
+    cleanup_series.add(series_id)
+
+    # Get data from DataReservoir.io
+    series_full_out = client.get(series_id, start=None, end=None)
+    series_partial_out = client.get(
+        series_id, start="2022-01-01 00:00", end="2022-01-02 00:00"
+    )
+
+    # Check downloaded data
+    series_empty = pd.Series(
+        index=pd.DatetimeIndex([], tz="utc"), dtype="object", name="values"
+    )
+    pd.testing.assert_series_equal(series_full_out, series_empty, check_freq=False)
+    pd.testing.assert_series_equal(series_partial_out, series_empty, check_freq=False)
+
+    # Delete timeseries from DataReservoir.io
+    client.delete(series_id)
+
+    # Check that the timeseries is deleted
+    with pytest.raises(HTTPError):
+        _ = client.get(series_id)


### PR DESCRIPTION
### This PR is related to user story DST-454

## Description
Integration test for creating/downloading empty timeseries from DataReservoir.io.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

