### PR TITLE
Check that data is read from cache in integration test w/caching

### DIFF
--- a/integration_tests/test_numeric_cached.py
+++ b/integration_tests/test_numeric_cached.py
@@ -103,7 +103,7 @@ def test_numeric_cached(cleanup_series, tmp_path):
     _ = client.get(series_id, start=None, end=None)
     time_after_get = time.time()
     for cache_file_i in CACHE_PATH.iterdir():
-        time_access_file_i = os.path.getatime(cache_file_i)   # last access time
+        time_access_file_i = os.path.getatime(cache_file_i)  # last access time
         assert time_before_get < time_access_file_i < time_after_get
 
     # Delete timeseries from DataReservoir.io

--- a/integration_tests/test_numeric_cached.py
+++ b/integration_tests/test_numeric_cached.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import numpy as np
 import pandas as pd
@@ -96,6 +97,16 @@ def test_numeric_cached(cleanup_series, tmp_path):
     pd.testing.assert_series_equal(
         series_a_and_b.loc[start : end - delta], series_partial, check_freq=False
     )
+
+    # Check that data is read from cache
+    time_before_get = time.time()
+    time.sleep(1)
+    _ = client.get(series_id, start=None, end=None)
+    time.sleep(1)
+    time_after_get = time.time()
+    for cache_file_i in CACHE_PATH.iterdir():
+        time_file_read_i = os.path.getatime(cache_file_i)
+        assert time_before_get < time_file_read_i < time_after_get
 
     # Delete timeseries from DataReservoir.io
     client.delete(series_id)

--- a/integration_tests/test_numeric_cached.py
+++ b/integration_tests/test_numeric_cached.py
@@ -100,13 +100,11 @@ def test_numeric_cached(cleanup_series, tmp_path):
 
     # Check that data is read from cache
     time_before_get = time.time()
-    time.sleep(1)
     _ = client.get(series_id, start=None, end=None)
-    time.sleep(1)
     time_after_get = time.time()
     for cache_file_i in CACHE_PATH.iterdir():
-        time_file_read_i = os.path.getatime(cache_file_i)
-        assert time_before_get < time_file_read_i < time_after_get
+        time_access_file_i = os.path.getatime(cache_file_i)   # last access time
+        assert time_before_get < time_access_file_i < time_after_get
 
     # Delete timeseries from DataReservoir.io
     client.delete(series_id)


### PR DESCRIPTION
### This PR is related to user story DST-466

## Description
Check that data is read from cache in integration test w/caching.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

