### PR TITLE
Test _df_to_blob with string values

### DIFF
--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -1,6 +1,6 @@
 import io
 from pathlib import Path
-from unittest.mock import ANY, Mock
+from unittest.mock import ANY
 
 import pandas as pd
 import pytest

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -152,9 +152,7 @@ class Test__df_to_blob:
             data=ANY,
         )
 
-        assert (
-            mock_requests.call_args.kwargs["data"].memory == data.as_binary_csv()
-        )
+        assert mock_requests.call_args.kwargs["data"].memory == data.as_binary_csv()
 
 
 class Test_Storage:

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -126,9 +126,11 @@ class Test__df_to_blob:
 
         return data_handler
 
-    def test__df_to_blob(self, data_float):
+    @pytest.mark.parametrize("data", ("data_float", "data_string"))
+    def test__df_to_blob(self, data, request):
+        data = request.getfixturevalue(data)
         blob_url = "http://example/blob/url"
-        _ = drio.storage.storage._df_to_blob(data_float.as_dataframe(), blob_url)
+        _ = drio.storage.storage._df_to_blob(data.as_dataframe(), blob_url)
 
     def test__df_to_blob_raises_series(self, data_float):
         with pytest.raises(ValueError):

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -108,6 +108,24 @@ class Test__df_to_blob:
 
         return data_handler
 
+    @pytest.fixture
+    def data_string(self):
+        index_list = (
+            1640995215379000000,
+            1640995219176000000,
+            1640995227270000000,
+            1640995267223000000,
+            1640995271472000000,
+        )
+
+        values_list = ("foo", "bar", "baz", "foobar", "abcd")
+
+        series = pd.Series(data=values_list, index=index_list, name="values")
+
+        data_handler = DataHandler(series)
+
+        return data_handler
+
     def test__df_to_blob(self, data_float):
         blob_url = "http://example/blob/url"
         _ = drio.storage.storage._df_to_blob(data_float.as_dataframe(), blob_url)

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -86,8 +86,6 @@ class Test__blob_to_df:
 class Test__df_to_blob:
     """
     Tests the :func:`_df_to_blob` function.
-
-    TODO: Test for DataFrame with string values.
     """
 
     @pytest.fixture

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -132,16 +132,20 @@ class Test__df_to_blob:
         blob_url = "http://example/blob/url"
         _ = drio.storage.storage._df_to_blob(data.as_dataframe(), blob_url)
 
-    def test__df_to_blob_raises_series(self, data_float):
+    @pytest.mark.parametrize("data", ("data_float", "data_string"))
+    def test__df_to_blob_raises_series(self, data, request):
+        data = request.getfixturevalue(data)
         with pytest.raises(ValueError):
             blob_url = "http://example/blob/url"
-            _ = drio.storage.storage._df_to_blob(data_float.as_series(), blob_url)
+            _ = drio.storage.storage._df_to_blob(data.as_series(), blob_url)
 
+    @pytest.mark.parametrize("data", ("data_float", "data_string"))
     def test__df_to_blob_call_args_2(
-        self, mock_requests, bytesio_with_memory, data_float
+        self, mock_requests, bytesio_with_memory, data, request
     ):
+        data = request.getfixturevalue(data)
         blob_url = "http://example/blob/url"
-        _ = drio.storage.storage._df_to_blob(data_float.as_dataframe(), blob_url)
+        _ = drio.storage.storage._df_to_blob(data.as_dataframe(), blob_url)
 
         mock_requests.assert_called_once_with(
             method="put",
@@ -151,7 +155,7 @@ class Test__df_to_blob:
         )
 
         assert (
-            mock_requests.call_args.kwargs["data"].memory == data_float.as_binary_csv()
+            mock_requests.call_args.kwargs["data"].memory == data.as_binary_csv()
         )
 
 


### PR DESCRIPTION
### This PR is related to user story DST-482

## Description
Tested `_df_to_blob()` function with string values. 

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

