### PR TITLE
Limit max_workers to 2

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -329,7 +329,7 @@ class Client:
         response_json = response.json()
 
         if response_json["Files"]:
-            with ThreadPoolExecutor(max_workers=None) as e:
+            with ThreadPoolExecutor(max_workers=2) as e:
                 futures = [
                     e.submit(
                         self._storage.get,


### PR DESCRIPTION
### This PR is related to user story DST-

## Description
Limit max workers to 2.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

