### PR TITLE
Add timeouts to all HTTP calls

### DIFF
--- a/datareservoirio/authenticate.py
+++ b/datareservoirio/authenticate.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 from abc import ABCMeta, abstractmethod
-from urllib3 import Retry
 
 from oauthlib.oauth2 import (
     BackendApplicationClient,
@@ -12,7 +11,7 @@ from oauthlib.oauth2 import (
 )
 from requests.adapters import HTTPAdapter
 from requests_oauthlib import OAuth2Session
-
+from urllib3 import Retry
 
 import datareservoirio as drio
 

--- a/datareservoirio/authenticate.py
+++ b/datareservoirio/authenticate.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from abc import ABCMeta, abstractmethod
+from urllib3 import Retry
 
 from oauthlib.oauth2 import (
     BackendApplicationClient,
@@ -9,7 +10,9 @@ from oauthlib.oauth2 import (
     MissingTokenError,
     WebApplicationClient,
 )
+from requests.adapters import HTTPAdapter
 from requests_oauthlib import OAuth2Session
+
 
 import datareservoirio as drio
 
@@ -88,6 +91,19 @@ class BaseAuthSession(OAuth2Session, metaclass=ABCMeta):
             client=client,
             **kwargs,
         )
+
+        # Attention: Be careful when extending the list of retry_status!
+        retry_status = frozenset([413, 429, 502, 503, 504])
+        allowed_methods = frozenset(["GET", "POST", "PUT", "PATCH", "DELETE"])
+
+        persist = Retry(
+            total=3,
+            backoff_factor=0.5,
+            allowed_methods=allowed_methods,
+            status_forcelist=retry_status,
+            raise_on_status=False,
+        )
+        self.mount(environment.api_base_url, HTTPAdapter(max_retries=persist))
 
         if auth_force or not self.token:
             token = self.fetch_token()

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -26,6 +26,8 @@ metric.addHandler(
 _END_DEFAULT = 9214646400000000000  # 2262-01-01
 _START_DEFAULT = -9214560000000000000  # 1678-01-01
 
+_TIMEOUT_DEAULT = 120
+
 
 class Client:
     """
@@ -68,7 +70,9 @@ class Client:
         Test that you have a working connection to DataReservoir.io.
 
         """
-        response = self._auth_session.get(environment.api_base_url + "ping")
+        response = self._auth_session.get(
+            environment.api_base_url + "ping", timeout=_TIMEOUT_DEAULT
+        )
         response.raise_for_status()
         return response.json()
 
@@ -101,7 +105,8 @@ class Client:
         """
         if series is None:
             response = self._auth_session.put(
-                environment.api_base_url + f"timeseries/{str(uuid4())}"
+                environment.api_base_url + f"timeseries/{str(uuid4())}",
+                timeout=_TIMEOUT_DEAULT,
             )
             response.raise_for_status()
             return response.json()
@@ -109,7 +114,7 @@ class Client:
         df = self._verify_and_prepare_series(series)
 
         response_file = self._auth_session.post(
-            environment.api_base_url + "files/upload"
+            environment.api_base_url + "files/upload", timeout=_TIMEOUT_DEAULT
         )
         response_file.raise_for_status()
         file_id, target_url = itemgetter("FileId", "Endpoint")(response_file.json())
@@ -117,7 +122,7 @@ class Client:
         commit_request = (
             "POST",
             environment.api_base_url + "files/commit",
-            {"json": {"FileId": file_id}},
+            {"json": {"FileId": file_id}, "timeout": _TIMEOUT_DEAULT},
         )
         self._storage.put(df, target_url, commit_request)
 
@@ -127,7 +132,9 @@ class Client:
                 return status
 
         response = self._auth_session.post(
-            environment.api_base_url + "timeseries/create", data={"FileId": file_id}
+            environment.api_base_url + "timeseries/create",
+            data={"FileId": file_id},
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -161,7 +168,7 @@ class Client:
         df = self._verify_and_prepare_series(series)
 
         response_file = self._auth_session.post(
-            environment.api_base_url + "files/upload"
+            environment.api_base_url + "files/upload", timeout=_TIMEOUT_DEAULT
         )
         response_file.raise_for_status()
         file_id, target_url = itemgetter("FileId", "Endpoint")(response_file.json())
@@ -169,7 +176,7 @@ class Client:
         commit_request = (
             "POST",
             environment.api_base_url + "files/commit",
-            {"json": {"FileId": file_id}},
+            {"json": {"FileId": file_id}, "timeout": _TIMEOUT_DEAULT},
         )
 
         self._storage.put(df, target_url, commit_request)
@@ -182,6 +189,7 @@ class Client:
         response = self._auth_session.post(
             environment.api_base_url + "timeseries/add",
             data={"TimeSeriesId": series_id, "FileId": file_id},
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -196,7 +204,8 @@ class Client:
             Available information about the series. None if series not found.
         """
         response = self._auth_session.get(
-            environment.api_base_url + f"timeseries/{series_id}"
+            environment.api_base_url + f"timeseries/{series_id}",
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -243,7 +252,8 @@ class Client:
             args = args[: args.index(None)]
 
         response = self._auth_session.get(
-            environment.api_base_url + f"timeseries/search/{'/'.join(args)}"
+            environment.api_base_url + f"timeseries/search/{'/'.join(args)}",
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -259,7 +269,8 @@ class Client:
 
         """
         return self._auth_session.delete(
-            environment.api_base_url + f"timeseries/{series_id}"
+            environment.api_base_url + f"timeseries/{series_id}",
+            timeout=_TIMEOUT_DEAULT,
         )
 
     def _timer(func):
@@ -343,7 +354,8 @@ class Client:
 
         response = self._auth_session.get(
             environment.api_base_url
-            + f"timeseries/{series_id}/data/days?start={start}&end={end}"
+            + f"timeseries/{series_id}/data/days?start={start}&end={end}",
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -417,6 +429,7 @@ class Client:
                     environment.api_base_url
                     + f"metadata/{namespace}/{key}?overwrite={'true' if overwrite else 'false'}",
                     json={"Value": namevalues},
+                    timeout=_TIMEOUT_DEAULT,
                 )
                 response_create.raise_for_status()
                 metadata_id = response_create.json()["Id"]
@@ -432,6 +445,7 @@ class Client:
         response = self._auth_session.put(
             environment.api_base_url + f"timeseries/{series_id}/metadata",
             json=[metadata_id],
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -457,6 +471,7 @@ class Client:
         response = self._auth_session.delete(
             environment.api_base_url + f"timeseries/{series_id}/metadata",
             json=[metadata_id],
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -485,6 +500,7 @@ class Client:
         response = self._auth_session.put(
             environment.api_base_url + f"metadata/{namespace}/{key}?overwrite=true",
             json={"Value": namevalues},
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -517,7 +533,9 @@ class Client:
                 "Missing required input: either (metadata_id) or (namespace, key)"
             )
 
-        response = self._auth_session.get(environment.api_base_url + uri_postfix)
+        response = self._auth_session.get(
+            environment.api_base_url + uri_postfix, timeout=_TIMEOUT_DEAULT
+        )
         response.raise_for_status()
         return response.json()
 
@@ -543,7 +561,9 @@ class Client:
         else:
             uri_postfix = f"metadata/{namespace}"
 
-        response = self._auth_session.get(environment.api_base_url + uri_postfix)
+        response = self._auth_session.get(
+            environment.api_base_url + uri_postfix, timeout=_TIMEOUT_DEAULT
+        )
         response.raise_for_status()
         return sorted(response.json())
 
@@ -566,6 +586,7 @@ class Client:
         response = self._auth_session.post(
             environment.api_base_url + "metadata/search",
             json={"Namespace": namespace, "Key": key, "Value": {}},
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()
@@ -580,7 +601,8 @@ class Client:
             id of metadata
         """
         response = self._auth_session.delete(
-            environment.api_base_url + f"metadata/{metadata_id}"
+            environment.api_base_url + f"metadata/{metadata_id}",
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return
@@ -618,7 +640,8 @@ class Client:
 
     def _get_file_status(self, file_id):
         response = self._auth_session.get(
-            environment.api_base_url + f"files/{file_id}/status"
+            environment.api_base_url + f"files/{file_id}/status",
+            timeout=_TIMEOUT_DEAULT,
         )
         response.raise_for_status()
         return response.json()["State"]

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -294,7 +294,7 @@ def _blob_to_df(blob_url):
         (``Int64``) and column ``values`` are ``str`` or ``float64``.
     """
 
-    response = requests.get(blob_url, stream=True)
+    response = requests.get(blob_url, stream=True, timeout=10)
     response.raise_for_status()
 
     with io.BytesIO() as stream:
@@ -348,6 +348,6 @@ def _df_to_blob(df, blob_url):
         fp.seek(0)
 
         requests.put(
-            blob_url, headers={"x-ms-blob-type": "BlockBlob"}, data=fp
+            blob_url, headers={"x-ms-blob-type": "BlockBlob"}, data=fp, timeout=10
         ).raise_for_status()
     return

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -348,6 +348,9 @@ def _df_to_blob(df, blob_url):
         fp.seek(0)
 
         requests.put(
-            blob_url, headers={"x-ms-blob-type": "BlockBlob"}, data=fp, timeout=10
+            blob_url,
+            headers={"x-ms-blob-type": "BlockBlob"},
+            data=fp,
+            timeout=(10, None),
         ).raise_for_status()
     return

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -106,7 +106,7 @@ class Test__df_to_blob:
             url=blob_url,
             headers={"x-ms-blob-type": "BlockBlob"},
             data=ANY,
-            timeout=10,
+            timeout=(10, None),
         )
 
         assert mock_requests.call_args.kwargs["data"].memory == data.as_binary_csv()
@@ -529,7 +529,7 @@ class Test_Storage:
             (
                 "POST",
                 "https://reservoir-api.4subsea.net/api/files/commit",
-                {"json": {"FileId": "1234"}},
+                {"json": {"FileId": "1234"}, "timeout": 10},
             ),
         )
 
@@ -539,12 +539,13 @@ class Test_Storage:
                 url="http://example/blob/url",
                 headers={"x-ms-blob-type": "BlockBlob"},
                 data=ANY,
-                timeout=10,
+                timeout=(10, None),
             ),
             call(
                 method="POST",
                 url="https://reservoir-api.4subsea.net/api/files/commit",
                 json={"FileId": "1234"},
+                timeout=10,
             ),
         ]
 

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -106,6 +106,7 @@ class Test__df_to_blob:
             url=blob_url,
             headers={"x-ms-blob-type": "BlockBlob"},
             data=ANY,
+            timeout=10,
         )
 
         assert mock_requests.call_args.kwargs["data"].memory == data.as_binary_csv()
@@ -538,6 +539,7 @@ class Test_Storage:
                 url="http://example/blob/url",
                 headers={"x-ms-blob-type": "BlockBlob"},
                 data=ANY,
+                timeout=10,
             ),
             call(
                 method="POST",


### PR DESCRIPTION
### This PR is related to user story DST-

## Description
Add timeouts to all http calls:
* 10 sec towards Azure
* 120 sec towards 4insight

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

