### PR TITLE
Add retry on requests towards Azure Blob Storage

### DIFF
--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -294,7 +294,9 @@ def _blob_to_df(blob_url):
         (``Int64``) and column ``values`` are ``str`` or ``float64``.
     """
 
-    response = requests.get(blob_url, stream=True, timeout=10)
+    with requests.Session() as session:
+        session.mount("https://", requests.adapters.HTTPAdapter(max_retries=3))
+        response = session.request(method="get", url=blob_url, stream=True, timeout=10)
     response.raise_for_status()
 
     with io.BytesIO() as stream:
@@ -347,10 +349,13 @@ def _df_to_blob(df, blob_url):
             df.to_csv(fp, line_terminator="\n", **kwargs)
         fp.seek(0)
 
-        requests.put(
-            blob_url,
-            headers={"x-ms-blob-type": "BlockBlob"},
-            data=fp,
-            timeout=(10, None),
-        ).raise_for_status()
+        with requests.Session() as session:
+            session.mount("https://", requests.adapters.HTTPAdapter(max_retries=3))
+            session.request(
+                method="put",
+                url=blob_url,
+                headers={"x-ms-blob-type": "BlockBlob"},
+                data=fp,
+                timeout=(10, None),
+            ).raise_for_status()
     return


### PR DESCRIPTION
### This PR is related to user story DST-

## Description
Add retry on requests towards Azure Blob. It will only retry on connection errors.
This will should remedy the occational connection exception errors.

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

