### PR TITLE
Fix closing connection before content is read

### DIFF
--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -301,6 +301,7 @@ def _blob_to_df(blob_url):
         content = io.BytesIO(response.content)
     response.raise_for_status()
 
+    #To handle malformed csv, DRIO assumes that everything is a two column csv. Must handle when there is more than or different delimiters besides a single comma on each line.
     if _check_malformatted(content):
         kwargs = {
             "sep": "^([0-9]+),",

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -301,7 +301,7 @@ def _blob_to_df(blob_url):
         content = io.BytesIO(response.content)
     response.raise_for_status()
 
-    #To handle malformed csv, DRIO assumes that everything is a two column csv. Must handle when there is more than or different delimiters besides a single comma on each line.
+    # To handle malformed csv, DRIO assumes that everything is a two column csv. Must handle when there is more than or different delimiters besides a single comma on each line.
     if _check_malformatted(content):
         kwargs = {
             "sep": "^([0-9]+),",

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -297,31 +297,27 @@ def _blob_to_df(blob_url):
     with requests.Session() as session:
         retries = requests.adapters.Retry(total=5, backoff_factor=0.4, backoff_max=10)
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retries))
-        response = session.request(method="get", url=blob_url, stream=True, timeout=30)
+        response = session.request(method="get", url=blob_url, timeout=30)
+        content = io.BytesIO(response.content)
     response.raise_for_status()
 
-    with io.BytesIO() as stream:
-        for chunk in response.iter_content(chunk_size=512):
-            stream.write(chunk)
+    if _check_malformatted(content):
+        kwargs = {
+            "sep": "^([0-9]+),",
+            "usecols": (1, 2),
+            "engine": "python",
+        }
+    else:
+        kwargs = {"sep": ","}
 
-        stream.seek(0)
-        if _check_malformatted(stream):
-            kwargs = {
-                "sep": "^([0-9]+),",
-                "usecols": (1, 2),
-                "engine": "python",
-            }
-        else:
-            kwargs = {"sep": ","}
-
-        df = pd.read_csv(
-            stream,
-            header=None,
-            names=("index", "values"),
-            dtype={"index": "int64", "values": "str"},
-            encoding="utf-8",
-            **kwargs,
-        ).astype({"values": "float64"}, errors="ignore")
+    df = pd.read_csv(
+        content,
+        header=None,
+        names=("index", "values"),
+        dtype={"index": "int64", "values": "str"},
+        encoding="utf-8",
+        **kwargs,
+    ).astype({"values": "float64"}, errors="ignore")
 
     return df
 


### PR DESCRIPTION
### This PR is related to user story [ESS-XXXX](url_to_jira_task)

## Description
Fixes an issue in _blob_to_df, where connection was set to stream=True and  closed, before content was read. This meant that the connection was available in the pool while the data was still being read.

If the connection is then reused by someone else, this would look like the connection broke from server side, potentially leading to all the ChunkedEncodingError and IncompleteReadError.

Fixed by reading the content all at once while connection was still open. No need for streaming, since we dont use the partial data.  

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  

