### PR TITLE
Enhance _blob_to_df

### DIFF
--- a/datareservoirio/_utils.py
+++ b/datareservoirio/_utils.py
@@ -28,9 +28,7 @@ class DataHandler:
         """Read data from CSV file"""
         with open(path, "r", encoding="utf-8") as fp:
             content = [
-                line.rstrip().split(",", maxsplit=1)
-                for line in fp.readlines()
-                if line
+                line.rstrip().split(",", maxsplit=1) for line in fp.readlines() if line
             ]
 
         df = (

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,10 +1,9 @@
-import io
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
-from datareservoirio._utils import DataHandler, _check_malformatted
+from datareservoirio._utils import DataHandler
 
 TEST_PATH = Path(__file__).parent
 
@@ -101,32 +100,3 @@ class Test_DataHandler:
         csv_path = TEST_PATH / "testdata" / csv_path
         data_handler = DataHandler.from_csv(csv_path)
         pd.testing.assert_series_equal(data_handler.as_series(), series)
-
-
-class Test__check_malformatted:
-    @pytest.mark.parametrize(
-        "filename, expect",
-        [
-            ("data_float.csv", False),
-            ("data_string.csv", False),
-            ("data_string_malformatted.csv", True),
-        ],
-    )
-    def test__check_malformatted_file(self, filename, expect):
-        filepath = TEST_PATH / "testdata" / filename
-        out = _check_malformatted(filepath)
-        assert out == expect
-
-    @pytest.mark.parametrize(
-        "filename, expect",
-        [
-            ("data_float.csv", False),
-            ("data_string.csv", False),
-            ("data_string_malformatted.csv", True),
-        ],
-    )
-    def test__check_malformatted_stream(self, filename, expect):
-        filepath = TEST_PATH / "testdata" / filename
-        with io.BytesIO(filepath.read_bytes()) as stream:
-            out = _check_malformatted(stream)
-        assert out == expect


### PR DESCRIPTION
### This PR is related to user story [ESS-2232](https://4insight.atlassian.net/browse/ESS-2232)

## Description
Refactor _blob_to_df to avoid pd.read_csv with 2 different options due to "malformed" csv content.
Instead, the content is read line-by-line and immediately split lines on first ",". Then the content (list of [index, value])
is used to create a DataFrame.

This provides a general blob -> df approach, not assuming that the content is csv-format. Instead, it is assumed that each
line is utf-encoded text with only 2  columns separated by ",".

Since the function is mostly IO bound, the refactor dont apprear to have introduced any perf penalty. On the other hand,
it will be faster for "malformed" csv content, i.e., content where each line is "index,arbitrary_str".

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  



[ESS-2232]: https://4insight.atlassian.net/browse/ESS-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ