### PR TITLE
ESS-2234: Add wrapper for new endpoint for fetching aggregated timeseries

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -3,6 +3,7 @@ import time
 import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from functools import wraps
 from operator import itemgetter
 from urllib.parse import urlencode
@@ -286,7 +287,7 @@ class Client:
         )
 
     def _timer(func):
-        """Decorator used to log latency of the ``get`` method"""
+        """Decorator used to log latency of the ``get`` and ``get_samples_aggregate`` method"""
 
         @wraps(func)
         def wrapper(self, series_id, start=None, end=None, **kwargs):
@@ -412,8 +413,19 @@ class Client:
 
         return series
 
-
-    def get_samples_aggregate(self, series_id, start=None, end=None, aggregation_period=None, aggregation_function=None, max_page_size=None):
+    @log_decorator("exception")
+    @_timer
+    @log_decorator("warning")
+    def get_samples_aggregate(
+        self,
+        series_id,
+        start=None,
+        end=None,
+        aggregation_period=None,
+        aggregation_function=None,
+        max_page_size=None,
+        convert_date=True,
+    ):
         """
         Retrieve a series from DataReservoir.io using the samples/aggregate endpoint.
 
@@ -421,64 +433,112 @@ class Client:
         ----------
         series_id : str
             Identifier of the series to download
-        start: optional
-            TODO
-        end: optional
-            TODO
+        start: required
+            Start time (inclusive) of the aggregated series given as anything
+            pandas.to_datetime is able to parse. Date must be within the past 90 days.
+        end:
+            Stop time (exclusive) of the aggregated series given as anything
+            pandas.to_datetime is able to parse. Date must be within the past 90 days.
         aggregation_function : str
-            TODO
+            One of "Avg", "Min", "Max", "Stdev".
         aggregation_period : str
-            TODO
+            Used in combination with aggregation function to specify the period for aggregation.
+            Aggregation period is maximum 24 hours. Values can be in units of h, m, s, ms,
+            microsecond or tick. Use 100 ms instead of 0.1s for 10Hz.
+        max_page_size : optional
+            Maximum number of samples to return per page. The method automatically follows links
+            to next pages and returns the entire series.
 
         Returns
         -------
         pandas.Series
             Series data
         """
-        params = {}
-        if not aggregation_period:
-            aggregation_period = "15m"
-        
-        if not aggregation_function:    
-            aggregation_function = "Avg"
-        
-        if max_page_size:
-            params["maxPageSize"] = max_page_size
-
         if not start:
-            # TODO
-            start = "2024-01-03"
+            # Required parameter
+            raise ValueError("You must specify the start date in ISO 8601 format.")
 
         if not end:
-            # TODO
-            end = "2024-01-04"
+            # Required parameter
+            raise ValueError("You must specify the end date in ISO 8601 format.")
+
+        if not aggregation_period:
+            # Required parameter
+            raise ValueError("You must specify the aggregation period.")
+
+        if not aggregation_function:
+            # Required parameter
+            raise ValueError("You must specify the aggregation function.")
+
+        start = pd.to_datetime(start, dayfirst=True, unit="ns", utc=True).isoformat()
+        end = pd.to_datetime(end, dayfirst=True, unit="ns", utc=True).isoformat()
+
+        params = {}
+
+        if max_page_size:
+            params["maxPageSize"] = max_page_size
 
         params["aggregationPeriod"] = aggregation_period
         params["aggregationFunction"] = aggregation_function
         params["start"] = start
         params["end"] = end
 
-        url = f"{environment.api_base_url}reservoir/timeseries/{series_id}/samples/aggregate?{urlencode(params)}"
+        next_page_link = f"{environment.api_base_url}reservoir/timeseries/{series_id}/samples/aggregate?{urlencode(params)}"
 
-        print(url)
-
-        response = self._auth_session.get(
-            url,
-            timeout=_TIMEOUT_DEAULT,
+        df = (
+            pd.DataFrame(columns=("index", "values"))
+            .astype({"index": "int64"})
+            .astype({"values": "float64"}, errors="ignore")
         )
-        response.raise_for_status()
-        response_json = response.json()
-        
-        content = [
-            (sample["Timestamp"], sample["Value"])
-            for sample in response["value"]
-        ]
 
-        df = pd.DataFrame(content, columns=("index", "values"), copy=False)
-            # .astype({"index": "int64"})
-            # .astype({"values": "float64"}, errors="ignore")
+        @retry(
+            stop=stop_after_attempt(
+                4
+            ),  # Attempt!, not retry attempt. Attempt 2, is 1 retry
+            retry=retry_if_exception_type(
+                (
+                    ConnectionError,
+                    requests.exceptions.ChunkedEncodingError,
+                    requests.ReadTimeout,
+                    ConnectionRefusedError,
+                    requests.ConnectionError,
+                )
+            ),
+            wait=wait_chain(*[wait_fixed(0.1), wait_fixed(0.5), wait_fixed(30)]),
+        )
+        def get_samples_aggregate_page(url):
+            return self._auth_session.get(
+                url,
+                timeout=_TIMEOUT_DEAULT,
+            )
 
-        series = df.set_index("index").squeeze("columns").loc[start:end].copy(deep=True)
+        while next_page_link:
+            response = get_samples_aggregate_page(next_page_link)
+            response.raise_for_status()
+            response_json = response.json()
+            if "@odata.nextLink" in response_json:
+                next_page_link = response_json["@odata.nextLink"]
+            else:
+                next_page_link = None
+
+            content = [
+                (pd.to_datetime(sample["Timestamp"]), sample["Value"])
+                for sample in response_json["value"]
+            ]
+
+            new_df = (
+                pd.DataFrame(content, columns=("index", "values"), copy=False)
+                .astype({"index": "int64"})
+                .astype({"values": "float64"}, errors="ignore")
+            )
+
+            df = pd.concat([df, new_df])
+
+        series = df.set_index("index").squeeze("columns").copy(deep=True)
+
+        series.index.name = None  # unsure what's the reason for this
+        if convert_date:
+            series.index = pd.to_datetime(series.index, utc=True)
 
         return series
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -448,7 +448,9 @@ class Client:
         max_page_size : optional
             Maximum number of samples to return per page. The method automatically follows links
             to next pages and returns the entire series.
-
+        convert_date : bool
+            If True (default), the index is converted to DatetimeIndex.
+            If False, index is returned as ascending integers.
         Returns
         -------
         pandas.Series

--- a/integration_tests/test_aggregate_samples.py
+++ b/integration_tests/test_aggregate_samples.py
@@ -1,0 +1,40 @@
+import os
+
+import pandas as pd
+import pytest
+from requests import HTTPError
+
+import datareservoirio as drio
+
+
+def test_empty(cleanup_series):
+    """
+    Integration test for the samples/aggregate endpoint.
+
+    Tests the following:
+        * Creates an empty timeseries in DataReservoir.io.
+        * Fetches it using the new endpoint.
+    """
+
+    # Initialize client
+    auth_session = drio.authenticate.ClientAuthenticator(
+        os.getenv("DRIO_CLIENT_ID"), os.getenv("DRIO_CLIENT_SECRET")
+    )
+    client = drio.Client(auth_session, cache=False)
+
+    # Create and upload timeseries to DataReservoir.io
+    response_create = client.create(series=None, wait_on_verification=True)
+    series_id = response_create["TimeSeriesId"]
+
+    # For cleaning up after test runs
+    cleanup_series.add(series_id)
+
+    # Get data from DataReservoir.io using the samples/aggregate endpoint
+    series = client.get_samples_aggregate(series_id)
+
+    # Check downloaded data
+    series_expected = pd.Series(
+        index=pd.DatetimeIndex([], tz="utc"), dtype="object", name="values"
+    )
+    pd.testing.assert_series_equal(series, series_expected, check_freq=False)
+

--- a/integration_tests/test_aggregate_samples.py
+++ b/integration_tests/test_aggregate_samples.py
@@ -1,19 +1,33 @@
 import os
 
+from datetime import datetime, timedelta
 import pandas as pd
+import numpy as np
+import time
 import pytest
-from requests import HTTPError
 
 import datareservoirio as drio
 
 
-def test_empty(cleanup_series):
+def wait_for_data_to_appear(func, delay=3):
+    count = 0
+    while count == 0:
+        series = func()
+        count = len(series)
+        if count == 0:
+            time.sleep(delay)
+        else:
+            return series
+
+
+def test_non_paged(cleanup_series):
     """
     Integration test for the samples/aggregate endpoint.
 
     Tests the following:
-        * Creates an empty timeseries in DataReservoir.io.
-        * Fetches it using the new endpoint.
+        * Creates a non-empty timeseries in DataReservoir.io.
+        * Fetches it using the samples/aggregate endpoint.
+        * Checks that the data matches with what was created.
     """
 
     # Initialize client
@@ -22,19 +36,77 @@ def test_empty(cleanup_series):
     )
     client = drio.Client(auth_session, cache=False)
 
-    # Create and upload timeseries to DataReservoir.io
-    response_create = client.create(series=None, wait_on_verification=True)
+    # Create some dummy data
+    # Relative from today, because we have the 3 month limitation
+    end = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    start = end - timedelta(hours=1)
+    freq = pd.to_timedelta(1, "s")
+    index = pd.date_range(start, end, freq=freq, tz="utc", inclusive="left")
+    series = pd.Series(data=np.random.random(len(index)), index=index, name="values")
+    response_create = client.create(series=series, wait_on_verification=True)
     series_id = response_create["TimeSeriesId"]
 
     # For cleaning up after test runs
     cleanup_series.add(series_id)
 
     # Get data from DataReservoir.io using the samples/aggregate endpoint
-    series = client.get_samples_aggregate(series_id)
+    get_timeseries = lambda: client.get_samples_aggregate(
+        series_id,
+        start=start,
+        end=end,
+        aggregation_function="Avg",
+        aggregation_period="1s",
+    )
+
+    # Wait for data to be available
+    series_fetched = wait_for_data_to_appear(get_timeseries)
 
     # Check downloaded data
-    series_expected = pd.Series(
-        index=pd.DatetimeIndex([], tz="utc"), dtype="object", name="values"
-    )
-    pd.testing.assert_series_equal(series, series_expected, check_freq=False)
+    pd.testing.assert_series_equal(series, series_fetched, check_freq=False)
 
+
+def test_paged(cleanup_series):
+    """
+    Integration test for the samples/aggregate endpoint.
+
+    Tests the following:
+        * Creates a non-empty timeseries in DataReservoir.io.
+        * Fetches it using the samples/aggregate endpoint and checks that the data is matches with what was created.
+        * uses a maxPageSize of 1000 which means the response will be paged (into 4 pages)
+    """
+
+    # Initialize client
+    auth_session = drio.authenticate.ClientAuthenticator(
+        os.getenv("DRIO_CLIENT_ID"), os.getenv("DRIO_CLIENT_SECRET")
+    )
+    client = drio.Client(auth_session, cache=False)
+
+    # Create some dummy data
+    # Relative from today, because we have the 3 month limitation
+    end = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+    start = end - timedelta(hours=1)
+    freq = pd.to_timedelta(1, "s")
+
+    index = pd.date_range(start, end, freq=freq, tz="utc", inclusive="left")
+    series = pd.Series(data=np.random.random(len(index)), index=index, name="values")
+    response_create = client.create(series=series, wait_on_verification=True)
+    series_id = response_create["TimeSeriesId"]
+
+    # For cleaning up after test runs
+    cleanup_series.add(series_id)
+
+    # Get data from DataReservoir.io using the samples/aggregate endpoint
+    check_func = lambda: client.get_samples_aggregate(
+        series_id,
+        start=start,
+        end=end,
+        aggregation_function="Avg",
+        aggregation_period="1s",
+        max_page_size=1000,
+    )
+
+    # Wait for data to be available
+    series_fetched = wait_for_data_to_appear(check_func)
+
+    # Check downloaded data
+    pd.testing.assert_series_equal(series, series_fetched, check_freq=False)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,8 +133,11 @@ class Test_Client:
         series_expect = group1_data.as_series()
         pd.testing.assert_series_equal(series_out, series_expect)
         # Check that the correct HTTP request is made
-        request_url_expect = "https://reservoir-api.4subsea.net/api/timeseries/2fee7f8a-664a-41c9-9b71-25090517c275/data/days?start=1672358400000000000&end=1672703939999999999"
-        mock_requests.call_args_list[0].kwargs["url"] = request_url_expect
+        if (start and end):
+            request_url_expect = "https://reservoir-api.4subsea.net/api/timeseries/2fee7f8a-664a-41c9-9b71-25090517c275/data/days?start=1672358400000000000&end=1672703939999999999"
+        else:
+            request_url_expect = "https://reservoir-api.4subsea.net/api/timeseries/2fee7f8a-664a-41c9-9b71-25090517c275/data/days?start=-9214560000000000000&end=9214646399999999999"
+        assert mock_requests.call_args_list[0].args[1] == request_url_expect
 
     def test_get_convert_date(self, client, group1_data, response_cases):
         response_cases.set("group1")
@@ -341,7 +344,7 @@ class Test_Client:
 
         # Check that the correct URL is poked
         request_url_expect = "https://reservoir-api.4subsea.net/api/timeseries/7bd106dd-d87f-4504-a888-6aeaff1ec31f"
-        mock_requests.call_args.kwargs["url"] = request_url_expect
+        assert mock_requests.call_args.args[1] == request_url_expect
 
     def test_create(self, client, monkeypatch, response_cases):
         response_cases.set("datareservoirio-api")


### PR DESCRIPTION
### This PR is related to user story [[ESS-2234](https://4insight.atlassian.net/browse/ESS-2234)]

## Description
This PR adds a new method `get_samples_aggregate` the `client` which is a wrapper to our new endpoint that supports simplified fetching of aggregated timeseries. It takes four required arguments: the start and end date, as anything which can be parsed by `pandas.to_datetime`, an aggregation period and an aggregation function, as well as optionally the max page size used when paging the response. The same [limitations](https://docs-test.4subsea.net/ess-api-docs/data-reservoir/index.html#tag/Timeseries/operation/get-timeseries-sampleaggregate) as in the API apply. As of now, there is no caching implemented for this method.

  

