### PR TITLE
ESS-2234-2: Improvements to fetching aggregate data

### DIFF
--- a/datareservoirio/_utils.py
+++ b/datareservoirio/_utils.py
@@ -67,7 +67,7 @@ class DataHandler:
 
 # Translation of user input parameters of the samples/aggregate method for more convenient use (matching pandas)
 
-function_translation = {"std": "Stdev", "mean": "Avg"}
+function_translation = {"std": "Stdev", "mean": "Avg", "min": "Min", "max": "Max"}
 
 period_translation = {
     "hours": "h",

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -440,7 +440,7 @@ class Client:
             Stop time (exclusive) of the aggregated series given as anything
             pandas.to_datetime is able to parse. Date must be within the past 90 days.
         aggregation_function : str
-            One of "Avg", "Min", "Max", "Stdev".
+            One of "mean", "min", "max", "std".
         aggregation_period : str
             Used in combination with aggregation function to specify the period for aggregation.
             Aggregation period is maximum 24 hours. Values can be in units of h, m, s, ms,
@@ -481,6 +481,9 @@ class Client:
         # Note the API is case insensitive so both min and Min will work
         if aggregation_function in function_translation:
             aggregation_function = function_translation[aggregation_function]
+
+        if not aggregation_period[0].isnumeric():
+            aggregation_period = "1" + aggregation_period
 
         for period_unit in period_translation:
             if (

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -40,6 +40,8 @@ _START_DEFAULT = -9214560000000000000  # 1678-01-01
 
 _TIMEOUT_DEAULT = 120
 
+_DEFAULT_MAX_PAGE_SIZE = 30000
+
 
 class Client:
     """
@@ -425,7 +427,7 @@ class Client:
         end=None,
         aggregation_period=None,
         aggregation_function=None,
-        max_page_size=None,
+        max_page_size=_DEFAULT_MAX_PAGE_SIZE,
     ):
         """
         Retrieve a series from DataReservoir.io using the samples/aggregate endpoint.
@@ -505,9 +507,8 @@ class Client:
 
         params = {}
 
-        if max_page_size:
-            params["maxPageSize"] = max_page_size
 
+        params["maxPageSize"] = max_page_size
         params["aggregationPeriod"] = aggregation_period
         params["aggregationFunction"] = aggregation_function
         params["start"] = start.isoformat()

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -507,7 +507,6 @@ class Client:
 
         params = {}
 
-
         params["maxPageSize"] = max_page_size
         params["aggregationPeriod"] = aggregation_period
         params["aggregationFunction"] = aggregation_function

--- a/docs/user_guide/manage_series.rst
+++ b/docs/user_guide/manage_series.rst
@@ -132,9 +132,9 @@ You can also access any data you have ``TimeSeriesId`` (and authorization) for w
 .. code-block:: python
 
     # Get entire timeseries
-    timeseries = client.get_samples_aggregate(series_id, start='2018-01-01',
-                            end='2018-01-02', aggregation_period='15m',
-                            aggregation_function='Avg')
+    timeseries = client.get_samples_aggregate(series_id, start='2024-01-01',
+                            end='2024-01-02', aggregation_period='15m',
+                            aggregation_function='mean')
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "importlib_resources",
     "opencensus-ext-azure",
     "tenacity",
-    "urllib3 > 2"
+    "urllib3 > 2",
+    "tqdm"
 ]
 
 [project.urls]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -890,7 +890,8 @@ class Test_Client:
 
     @pytest.mark.response_irrelevant
     @pytest.mark.parametrize(
-        "aggregation_function, expected", [("mean", "Avg"), ("std", "Stdev"), ("min", "Min"), ("max", "Max")]
+        "aggregation_function, expected",
+        [("mean", "Avg"), ("std", "Stdev"), ("min", "Min"), ("max", "Max")],
     )
     def test_aggregation_function_gets_translated(
         self, client, mock_requests, aggregation_function, expected, response_cases

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -890,7 +890,7 @@ class Test_Client:
 
     @pytest.mark.response_irrelevant
     @pytest.mark.parametrize(
-        "aggregation_function, expected", [("mean", "Avg"), ("std", "Stdev")]
+        "aggregation_function, expected", [("mean", "Avg"), ("std", "Stdev"), ("min", "Min"), ("max", "Max")]
     )
     def test_aggregation_function_gets_translated(
         self, client, mock_requests, aggregation_function, expected, response_cases
@@ -912,6 +912,9 @@ class Test_Client:
     @pytest.mark.parametrize(
         "aggregation_period, expected",
         [
+            ("min", "1m"),
+            ("tick", "1tick"),
+            ("s", "1s"),
             ("15minutes", "15m"),
             ("15minute", "15m"),
             ("15min", "15m"),


### PR DESCRIPTION
### This PR is related to user story [ESS-2234](url_to_jira_task)

## Description
A couple improvements to the work done on making a method to get aggregate data using the client.
- allowing an aggregation period input like "min" or "h", with meaning "1min", "1h"
- specifying the more familiar pandas abbreviations in doc strings
- adding a progress bar when paging (more like progress "information", as we don't know the total number of samples we're going to fetch"
- increased the default max_page_size because using 3600 is too low - the overhead for each requests then makes fetching the data overall a lot slower

https://github.com/4Subsea/drio-python/assets/152614622/0e37ac7d-f585-4cec-8b47-218794818022

https://github.com/4Subsea/drio-python/assets/152614622/72830412-7337-46a3-a281-eeff50334167





## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


PR title tips:
* Use imperative mood
* Describe the motivation for change, issue that has been solved or what has been improved - not how
* Examples:
  * Add functionality for Allan variance to sensor_4s.simulate
  * Upgrade to support Python 9.10
  * Remove MacOS from CI
  



[ESS-2234]: https://4insight.atlassian.net/browse/ESS-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ