### PR TITLE
Make progress bar dependent on log level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2
@@ -38,4 +38,4 @@ jobs:
 
       - name: Test doc build with tox
         run: tox -e docs
-        if: ${{ (matrix.python-version == '3.10') && (matrix.os == 'ubuntu-latest')}}
+        if: ${{ (matrix.python-version == '3.11') && (matrix.os == 'ubuntu-latest')}}

--- a/.github/workflows/deploy_public.yml
+++ b/.github/workflows/deploy_public.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/datareservoirio/appdirs.py
+++ b/datareservoirio/appdirs.py
@@ -3,6 +3,7 @@ This code was taken from https://github.com/ActiveState/appdirs and
 https://github.com/pypa/pip/blob/master/src/pip/_internal/utils/appdirs.py and
 modified to suit our purposes.
 """
+
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -571,7 +571,9 @@ class Client:
             df = pd.concat([df, new_df])
         if log.getEffectiveLevel() < logging.WARNING:
             progress_bar.close()
-        series = df.set_index("index").squeeze("columns").copy(deep=True)
+        series = (
+            df.infer_objects().set_index("index").squeeze("columns").copy(deep=True)
+        )
 
         return series
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -543,7 +543,9 @@ class Client:
                 timeout=_TIMEOUT_DEAULT,
             )
 
-        progress_bar = tqdm(unit=" pages", desc="Downloading aggregate data")
+        if log.getEffectiveLevel() < logging.WARNING:
+            progress_bar = tqdm(unit=" pages", desc="Downloading aggregate data")
+
         while next_page_link:
             response = get_samples_aggregate_page(next_page_link)
             response.raise_for_status()
@@ -559,7 +561,7 @@ class Client:
             ]
 
             # update the progress bar
-            if content:
+            if content and log.getEffectiveLevel() < logging.WARNING:
                 progress_bar.update(1)
 
             new_df = pd.DataFrame(
@@ -567,8 +569,8 @@ class Client:
             ).astype({"values": "float64"}, errors="ignore")
 
             df = pd.concat([df, new_df])
-
-        progress_bar.close()
+        if log.getEffectiveLevel() < logging.WARNING:
+            progress_bar.close()
         series = df.set_index("index").squeeze("columns").copy(deep=True)
 
         return series

--- a/docs/user_guide/advanced_config.rst
+++ b/docs/user_guide/advanced_config.rst
@@ -107,7 +107,10 @@ Logging
 To simplify debugging, enable logging for the logger named 'datareservoirio'. This is especially helpful if you experience undesired behavior in your application. 
 
 If your logging requirements are solely related to :py:mod:`datareservoirio`, you can use the following code. This will provide you with an understanding of the progress made in some 
-of the processes in the package. It is recommended to use this logging.
+of the processes in the package. 
+In particular, when using :py:meth:`Client.get_samples_aggregate`, lowering the log level below WARNING triggers a progress bar during data collection. 
+The default log level for the logger named 'datareservoirio' is WARNING.
+It is recommended to use this logging.
 
 .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ dynamic = ["version"]
 description = "DataReservoir.io Python API"
 readme = "README.rst"
 license = { file="LICENSE" }
-requires-python = ">3.9"
+requires-python = ">3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "numpy",
@@ -69,7 +69,7 @@ deps =
 
 
 [testenv:docs]
-basepython = python3.10
+basepython = python3.11
 commands = sphinx-build -W -b html -d {toxworkdir}/docs_doctree docs {toxworkdir}/docs_out
 deps =
     sphinx==5.3.0

--- a/tests/response_cases.py
+++ b/tests/response_cases.py
@@ -15,6 +15,7 @@ following attributes can be used as needed:
 Note that ``url`` is defined as part of the key in RESPONSE_CASES.
 See ``requests.Response`` source code for more details.
 """
+
 from pathlib import Path
 
 TEST_PATH = Path(__file__).parent


### PR DESCRIPTION
### This PR is related to user story [ESS-2553](https://4insight.atlassian.net/jira/software/c/projects/ESS/boards/34?assignee=712020%3A1e487ee8-2695-4136-b08a-1d3ba83ece75&selectedIssue=ESS-2553)

## Description
Based on feedback from user of the package we have set the progress bar to only be visible if the user of the package sets the log level to below WARNING. WARNING is the default log level for the package. The change also handles a future warning in pandas.  

## Checklist
- [x] PR title is descriptive and fit for injection into release notes (see tips below)
- [x] Correct label(s) are used


  



[ESS-2553]: https://4insight.atlassian.net/browse/ESS-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ