### PR TITLE
Ensure sorted data on upload of data from python 

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -128,7 +128,9 @@ class Client:
             return response.json()
 
         if not series.index.is_monotonic_increasing:
-            raise ValueError("Index not sorted. Please sort series on index before creating a timeseries.")
+            raise ValueError(
+                "Index not sorted. Please sort series on index before creating a timeseries."
+            )
 
         df = self._verify_and_prepare_series(series)
 
@@ -423,7 +425,9 @@ class Client:
                 df.set_index("index").squeeze("columns").loc[start:end].copy(deep=True)
             )
         except KeyError as e:
-            logging.warning("KeyError. The data will be sorted to attempt to resolve the issue. Please note that this operation may take some time.")
+            logging.warning(
+                "KeyError. The data will be sorted to attempt to resolve the issue. Please note that this operation may take some time."
+            )
             series = (
                 df.set_index("index")
                 .sort_index()
@@ -435,8 +439,6 @@ class Client:
 
         if series.empty and raise_empty:  # may become empty after slicing
             raise ValueError("can't find data in the given interval")
-
-
 
         if convert_date:
             series.index = pd.to_datetime(series.index, utc=True)

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -426,7 +426,7 @@ class Client:
             )
         except KeyError as e:
             logging.warning(
-                "KeyError. The data will be sorted to attempt to resolve the issue. Please note that this operation may take some time."
+                "The time series you requested is not properly ordered. The data will be sorted to attempt to resolve the issue. Please note that this operation may take some time."
             )
             series = (
                 df.set_index("index")

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -38,7 +38,7 @@ explained below.
 Series
 ------
 A series is a one-dimensional sequence with numeric values (64-bit float) and
-unique indicies (64-bit integer). (Consequently, each numeric value is natively
+unique indicies (64-bit integer) (Consequently, each numeric value is natively
 represented with 128-bits.) Each series is assigned a unique identifier
 `TimeSeriesId` (guid) for convenient access. Furthermore, a series can be
 enriched with :ref:`metadata <metadata>`.
@@ -76,8 +76,8 @@ But, that responsibility is left to the user/app/service that uses
 
 Metadata entries are organized using ``namespace`` and ``key``. A ``namespace``
 can be thought of as a table and ``key`` is the row index. Then a row can have
-any number of arbitrary number of columns. (Note that rows in a table do not 
-have to share the columns!). This resembles "table storage" paradigm for those
+any number of arbitrary number of columns (Note that rows in a table do not 
+have to share the columns). This resembles "table storage" paradigm for those
 who are familiar with that.
 
 Thus, a ``namespace`` and ``key`` combination uniquely defines a metadata

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -38,8 +38,8 @@ explained below.
 Series
 ------
 A series is a one-dimensional sequence with numeric values (64-bit float) and
-unique indicies (64-bit integer) (Consequently, each numeric value is natively
-represented with 128-bits.) Each series is assigned a unique identifier
+unique indices (64-bit integer). Consequently, each numeric value is natively
+represented with 128-bits. Each series is assigned a unique identifier
 `TimeSeriesId` (guid) for convenient access. Furthermore, a series can be
 enriched with :ref:`metadata <metadata>`.
 

--- a/docs/user_guide/manage_series.rst
+++ b/docs/user_guide/manage_series.rst
@@ -48,8 +48,8 @@ information is returned:
     converted to UTC and therefore, time zone information is lost when data is
     stored in `DataReservoir.io`_.
 
-You can also store a sequence of data. However, you are required to define an
-integer index. (This is useful when appending and updating the data later.)
+You can also store a sequence of data. However, you are required to define an increasing
+integer index. This is useful when appending and updating the data later.
 
 Store sequence:
 
@@ -75,6 +75,9 @@ data:
     series_id = response['TimeSeriesId']
     response = client.append(series, series_id)
 
+.. important::
+
+    The index of the series must be sorted. This is also also efficient when accessing the data later.
 
 Data verification process
 -------------------------

--- a/docs/user_guide/manage_series.rst
+++ b/docs/user_guide/manage_series.rst
@@ -77,7 +77,7 @@ data:
 
 .. important::
 
-    The index of the series must be sorted. This is also also efficient when accessing the data later.
+    The index of the series must be sorted. This is also efficient when accessing the data later.
 
 Data verification process
 -------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -206,7 +206,7 @@ class Test_Client:
             with patch("datareservoirio.logging.warning") as mock_logging_warning:
                 result = client.get(series_id, start, end)
                 mock_logging_warning.assert_called_once_with(
-                    "KeyError. The data will be sorted to attempt to resolve the issue. Please note that this operation may take some time."
+                    "The time series you requested is not properly ordered. The data will be sorted to attempt to resolve the issue. Please note that this operation may take some time."
                 )
                 assert isinstance(result, pd.Series)
 
@@ -569,7 +569,7 @@ class Test_Client:
         with pytest.raises(HTTPError):
             client.append(data_float.as_series(), series_id, wait_on_verification=True)
 
-    def test_apppend_raises_valueerror_unsorted_index(self, client):
+    def test_append_raises_valueerror_unsorted_index(self, client):
         series_id = "d30519af-5035-4093-a425-dafd857ad0ef"
         data = pd.Series(
             [1, 2, 3],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -427,6 +427,22 @@ class Test_Client:
         with pytest.raises(HTTPError):
             client.create(series=data_float.as_series(), wait_on_verification=True)
 
+    def test_create_raises_valueerror_unsorted_index(self, client):
+        data = pd.Series(
+            [1, 2, 3],
+            index=[
+                pd.to_datetime("2022-04-04"),
+                pd.to_datetime("2022-04-03"),
+                pd.to_datetime("2022-04-05"),
+            ],
+        )
+        with pytest.raises(ValueError) as e:
+            client.create(data)
+        assert (
+            str(e.value)
+            == "Index not sorted. Please sort series on index before creating a timeseries."
+        )
+
     def test_append(
         self, client, data_float, mock_requests, bytesio_with_memory, response_cases
     ):
@@ -500,6 +516,23 @@ class Test_Client:
         series_id = "d30519af-5035-4093-a425-dafd857ad0ef"
         with pytest.raises(HTTPError):
             client.append(data_float.as_series(), series_id, wait_on_verification=True)
+
+    def test_apppend_raises_valueerror_unsorted_index(self, client):
+        series_id = "d30519af-5035-4093-a425-dafd857ad0ef"
+        data = pd.Series(
+            [1, 2, 3],
+            index=[
+                pd.to_datetime("2022-04-04"),
+                pd.to_datetime("2022-04-03"),
+                pd.to_datetime("2022-04-05"),
+            ],
+        )
+        with pytest.raises(ValueError) as e:
+            client.append(data, series_id)
+        assert (
+            str(e.value)
+            == "Index not sorted. Please sort series on index before appending data."
+        )
 
     @pytest.mark.parametrize("data", ("data_float", "data_string"))
     def test__verify_and_prepare_series(self, client, data, request):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import time
 import types
 from encodings.utf_8 import encode
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -14,11 +15,6 @@ from tenacity import RetryError
 import datareservoirio as drio
 from datareservoirio._logging import exceptions_logger
 from datareservoirio._utils import DataHandler
-
-
-import pytest
-import pandas as pd
-from unittest.mock import MagicMock, patch
 
 TEST_PATH = Path(__file__).parent
 
@@ -62,11 +58,10 @@ def fail_with_invalid_json_error(self, url, timeout):
     else:
         raise InvalidJSONError()
 
+
 def _mock_blob_sequence_days(response_json):
-    return {
-        1: "file1",
-        2: "file2"
-    }
+    return {1: "file1", 2: "file2"}
+
 
 class Test_Client:
     """
@@ -168,7 +163,6 @@ class Test_Client:
         with pytest.raises(ValueError):
             client.get("e3d82cda-4737-4af9-8d17-d9dfda8703d0", raise_empty=True)
 
-
     def test_get_keyerror(self, client):
         series_id = "test_series_id"
         start = "2023-01-01"
@@ -177,29 +171,44 @@ class Test_Client:
         response_mock = MagicMock()
         response_mock.status_code = 200
         response_mock.json.return_value = {
-            "Files": [{"Chunks": "file1"}, {"Chunks": "file2"}]  # mock files with correct structure
+            "Files": [
+                {"Chunks": "file1"},
+                {"Chunks": "file2"},
+            ]  # mock files with correct structure
         }
 
         client._auth_session.get = MagicMock(return_value=response_mock)
 
         def mock_storage_get(blob_sequence_i):
             if blob_sequence_i == "file1":
-                return pd.DataFrame({'index': [1672358410000000000, 1672358400000000000], 'values': [100, 200]})
+                return pd.DataFrame(
+                    {
+                        "index": [1672358410000000000, 1672358400000000000],
+                        "values": [100, 200],
+                    }
+                )
             elif blob_sequence_i == "file2":
-                return pd.DataFrame({'index': [1672358410000000000, 1672358420000000000], 'values': [200, 400]})
+                return pd.DataFrame(
+                    {
+                        "index": [1672358410000000000, 1672358420000000000],
+                        "values": [200, 400],
+                    }
+                )
             else:
                 raise ValueError("Unexpected blob_sequence_i value")
-            
+
         client._storage.get = MagicMock(side_effect=mock_storage_get)
 
-        with patch('datareservoirio.client._blob_sequence_days', side_effect=_mock_blob_sequence_days):
-            with patch('datareservoirio.logging.warning') as mock_logging_warning:
+        with patch(
+            "datareservoirio.client._blob_sequence_days",
+            side_effect=_mock_blob_sequence_days,
+        ):
+            with patch("datareservoirio.logging.warning") as mock_logging_warning:
                 result = client.get(series_id, start, end)
                 mock_logging_warning.assert_called_once_with(
                     "KeyError. The data will be sorted to attempt to resolve the issue. Please note that this operation may take some time."
                 )
                 assert isinstance(result, pd.Series)
-       
 
     def test_get_raises_end_not_after_start(self, client):
         start = 1672358400000000000


### PR DESCRIPTION
### This PR is related to user story [ESS-2644](2644)

## Description
Not allowed to create and append to timeseries of the index is not sorted. If a KeyError is raised when trying to get data, the data is sorted before once more trying to access the specific date range.




[ESS-2644]: https://4insight.atlassian.net/browse/ESS-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ