### PR TITLE
ESS-3159 - doc changes wrt supported Python versions, setting QA for integration tests 

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,7 +8,7 @@ Head over to `Python.org`_ for instructions.
 
 Python version support
 ----------------------
-Officially Python 3.9, 3.10, and 3.11. We aim to support the three most
+Officially Python 3.10, 3.11, and 3.12. We aim to support the three most
 recent major versions.
 
 OS support

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -9,7 +9,7 @@ import datareservoirio as drio
 @pytest.fixture(autouse=True, scope="session")
 def set_environment_qa():
     """Set environment to 'QA'"""
-    env = drio.environments.Environment()
+    env = drio.globalsettings.environment
     env.set_qa()
 
 


### PR DESCRIPTION
### This PR is related to user story [ESS-3159](https://4insight.atlassian.net/browse/ESS-3159)

## Description
4insight documentation has been updated to inform users about supported Python versions (3.10, 3.11, 3.12).
Furthermore, integration test configuration was fixed, to target QA environment, instead of PROD.

That version does not require new drio-package deployment. The only thing to be replaced is documentation on docs.4insight.io.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used

