### PR TITLE
ESS-3166 - GitHub download/upload-artifacts update from v3 to v4

### DIFF
--- a/.github/workflows/deploy_public.yml
+++ b/.github/workflows/deploy_public.yml
@@ -105,7 +105,7 @@ jobs:
           sphinx-build -b html ./docs ./build/html
           
       - name: Stash build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_artifacts
           path: |
@@ -126,7 +126,7 @@ jobs:
         run: Get-ChildItem . | Remove-Item -Recurse -Force
 
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_artifacts
       
@@ -168,7 +168,7 @@ jobs:
         run: Get-ChildItem . | Remove-Item -Recurse -Force
 
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build_artifacts
 


### PR DESCRIPTION
### This PR is related to user story [[ESS-3166](https://4insight.atlassian.net/browse/ESS-3166)](https://4insight.atlassian.net/browse/ESS-3166)

## Description
Github will soon deprecate v2 and v3 of `download-artifact` and `upload-artifact` actions. Deploy workflow was changed to use v4 versions of those artifacts.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used




[ESS-3166]: https://4insight.atlassian.net/browse/ESS-3166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ