### PR TITLE
ESS-3357 Document how to convert boolean values after DRIO has stopped doing implicit conversion

### DIFF
--- a/docs/user_guide/access_data.rst
+++ b/docs/user_guide/access_data.rst
@@ -71,7 +71,7 @@ or contact support to restore it.
 .. warning::
 
     Regarding boolean values (true and false). A change in DRIO affects data ingested after approximately 10th of March 2025 10:00, booleans are no longer automatically converted to integer values 1 and 0.
-    This can be done manually where required by using the following code after downloading the data as shown above:
+    If this conversion is desried, it can be done manually where required by using the following code after downloading the data as shown above:
     
     .. code-block:: python
     timeseries.replace({True: 1, 'true': 1, 'True': 1, False: 0, 'false': 0, 'False': 0}, inplace=True)

--- a/docs/user_guide/access_data.rst
+++ b/docs/user_guide/access_data.rst
@@ -74,6 +74,7 @@ or contact support to restore it.
     If this conversion is desried, it can be done manually where required by using the following code after downloading the data as shown above:
     
     .. code-block:: python
+
     timeseries.replace({True: 1, 'true': 1, 'True': 1, False: 0, 'false': 0, 'False': 0}, inplace=True)
 
 .. tip::

--- a/docs/user_guide/access_data.rst
+++ b/docs/user_guide/access_data.rst
@@ -68,6 +68,13 @@ or contact support to restore it.
 
     The time resolution of aggregated data is in ticks (1tick = 100 nanoseconds), while the time resolution of non-aggregated data is in nanoseconds. This may lead to discrepancies in data when comparing the two, and some datapoints might get lost when using aggregation to access data, in cases when there are multiple datapoints within the same 100 nanosecond range.
 
+.. warning::
+
+    Regarding boolean values (true and false). A change in DRIO affects data ingested after approximately 10th of March 2025 10:00, booleans are no longer automatically converted to integer values 1 and 0.
+    This can be done manually where required by using the following code after downloading the data as shown above:
+    
+    .. code-block:: python
+    timeseries.replace({True: 1, 'true': 1, 'True': 1, False: 0, 'false': 0, 'False': 0}, inplace=True)
 
 .. tip::
     When handling high-frequency data and/or extended timespans, it is crucial to consider memory usage. 


### PR DESCRIPTION
### This PR is related to user story [ESS-3357](https://4insight.atlassian.net/browse/ESS-3357)

## Description
Provide documentation on how to deal with conversion of boolean values after DRIO stopped
doing automatic conversion of true and false to 1 and 0 for archived data. Users could rely on data
having been automatically converted to 1 and 0, this one line of code in the documentation illustrates how to
get the old behavior. 

In the future, this might be added as an optional parameter to the get method.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used



[ESS-3357]: https://4insight.atlassian.net/browse/ESS-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ