### PR TITLE
ESS-3444 Moving to Open Telemetry from Open Census

### DIFF
--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from functools import wraps, cache
+from functools import cache, wraps
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -19,8 +19,8 @@ def get_exceptions_logger() -> logging.Logger:
         enable_app_insights = os.environ[ENV_VAR_ENABLE_APP_INSIGHTS].lower()
         if enable_app_insights == "true" or enable_app_insights == "1":
             configure_azure_monitor(
-                connection_string=environment._application_insight_connectionstring
-                logger_name = __name__ + "exceptions_logger"  
+                connection_string=environment._application_insight_connectionstring,
+                logger_name=__name__ + "_exceptions_logger",
             )
             exceptions_logger.setLevel("WARNING")
 

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -2,12 +2,13 @@ import logging
 import os
 from functools import wraps, cache
 
-from opencensus.ext.azure.log_exporter import AzureLogHandler
+from azure.monitor.opentelemetry import configure_azure_monitor
 
 import datareservoirio as drio
 
 from ._constants import ENV_VAR_ENABLE_APP_INSIGHTS, ENV_VAR_ENGINE_ROOM_APP_ID
 from .globalsettings import environment
+
 
 @cache
 def get_exceptions_logger() -> logging.Logger:
@@ -17,12 +18,14 @@ def get_exceptions_logger() -> logging.Logger:
     if os.getenv(ENV_VAR_ENABLE_APP_INSIGHTS) is not None:
         enable_app_insights = os.environ[ENV_VAR_ENABLE_APP_INSIGHTS].lower()
         if enable_app_insights == "true" or enable_app_insights == "1":
-            app_insight_handler = AzureLogHandler(
+            configure_azure_monitor(
                 connection_string=environment._application_insight_connectionstring
+                logger_name = __name__ + "exceptions_logger"  
             )
-            app_insight_handler.setLevel("WARNING")
-            exceptions_logger.addHandler(app_insight_handler)
+            exceptions_logger.setLevel("WARNING")
+
     return exceptions_logger
+
 
 def log_decorator(log_level):
     def decorator(func):

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -4,15 +4,15 @@ import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from functools import wraps, cache
+from functools import cache, wraps
 from operator import itemgetter
 from urllib.parse import urlencode
 from uuid import uuid4
-from azure.monitor.opentelemetry import configure_azure_monitor
 
 import numpy as np
 import pandas as pd
 import requests
+from azure.monitor.opentelemetry import configure_azure_monitor
 from tenacity import (
     retry,
     retry_if_exception_type,

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -327,13 +327,11 @@ class Client:
                 ).isoformat()
             number_of_samples = len(result)
             properties = {
-                "custom_dimensions": {
-                    "series_id": series_id,
-                    "start": start_date_as_str,
-                    "end": end_date_as_str,
-                    "elapsed": elapsed_time,
-                    "number-of-samples": number_of_samples,
-                }
+                "series_id": series_id,
+                "start": start_date_as_str,
+                "end": end_date_as_str,
+                "elapsed": elapsed_time,
+                "number-of-samples": number_of_samples,
             }
             metric().info("Timer", extra=properties)
             return result

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -8,11 +8,11 @@ from functools import wraps, cache
 from operator import itemgetter
 from urllib.parse import urlencode
 from uuid import uuid4
+from azure.monitor.opentelemetry import configure_azure_monitor
 
 import numpy as np
 import pandas as pd
 import requests
-from opencensus.ext.azure.log_exporter import AzureLogHandler
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -29,14 +29,17 @@ from .storage import Storage
 
 log = logging.getLogger(__name__)
 
+
 @cache
 def metric() -> logging.Logger:
     logger = logging.getLogger(__name__ + "_metric_appinsight")
     logger.setLevel(logging.DEBUG)
-    logger.addHandler(
-        AzureLogHandler(connection_string=environment._application_insight_connectionstring)
+    configure_azure_monitor(
+        connection_string=environment._application_insight_connectionstring,
+        logger_name=__name__ + "_metric_appinsight",
     )
     return logger
+
 
 # Default values to push as start/end dates. (Limited by numpy.datetime64)
 _END_DEFAULT = 9214646400000000000  # 2262-01-01

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 import warnings
 from collections import defaultdict
@@ -22,6 +23,8 @@ from tenacity import (
 )
 from tqdm.auto import tqdm
 
+from datareservoirio._constants import ENV_VAR_ENABLE_APP_INSIGHTS
+
 from ._logging import log_decorator
 from ._utils import function_translation, period_translation
 from .globalsettings import environment
@@ -33,11 +36,14 @@ log = logging.getLogger(__name__)
 @cache
 def metric() -> logging.Logger:
     logger = logging.getLogger(__name__ + "_metric_appinsight")
-    logger.setLevel(logging.DEBUG)
-    configure_azure_monitor(
-        connection_string=environment._application_insight_connectionstring,
-        logger_name=__name__ + "_metric_appinsight",
-    )
+    if os.getenv(ENV_VAR_ENABLE_APP_INSIGHTS) is not None:
+        enable_app_insights = os.environ[ENV_VAR_ENABLE_APP_INSIGHTS].lower()
+        if enable_app_insights == "true" or enable_app_insights == "1":
+            logger.setLevel(logging.DEBUG)
+            configure_azure_monitor(
+                connection_string=environment._application_insight_connectionstring,
+                logger_name=__name__ + "_metric_appinsight",
+            )
     return logger
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,34 +4,32 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datareservoirio"
-authors = [
-    { name="4Subsea", email="support@4subsea.com" }
-]
+authors = [{ name = "4Subsea", email = "support@4subsea.com" }]
 dynamic = ["version"]
 description = "DataReservoir.io Python API"
 readme = "README.rst"
-license = { file="LICENSE" }
+license = { file = "LICENSE" }
 requires-python = ">3.10"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
+  "Development Status :: 5 - Production/Stable",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "numpy",
-    "oauthlib",
-    "pandas",
-    "pyarrow",
-    "requests",
-    "requests-oauthlib",
-    "importlib_resources",
-    "opencensus-ext-azure",
-    "tenacity<8.5",
-    "urllib3 > 2",
-    "tqdm"
+  "numpy",
+  "oauthlib",
+  "pandas",
+  "pyarrow",
+  "requests",
+  "requests-oauthlib",
+  "importlib_resources",
+  "tenacity<8.5",
+  "urllib3 > 2",
+  "tqdm",
+  "azure-monitor-opentelemetry",
 ]
 
 [project.urls]
@@ -45,7 +43,7 @@ include = ["datareservoirio*"]
 namespaces = false
 
 [tool.setuptools.dynamic]
-version = {attr = "datareservoirio.__version__"}
+version = { attr = "datareservoirio.__version__" }
 
 [tool.pytest.ini_options]
 pythonpath = [".", "src"]
@@ -75,3 +73,4 @@ deps =
     pydata-sphinx-theme==0.11.0
     myst_parser<2.0
 """
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import logging
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import Mock
@@ -11,14 +10,6 @@ import response_cases as rc
 from datareservoirio._utils import DataHandler
 
 TEST_PATH = Path(__file__).parent
-
-
-@pytest.fixture(autouse=True)
-def disable_logging(monkeypatch):
-    """Disable logging to Application Insight"""
-
-
-#    monkeypatch.setattr("datareservoirio.client.AzureLogHandler", logging.NullHandler())
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,9 @@ TEST_PATH = Path(__file__).parent
 @pytest.fixture(autouse=True)
 def disable_logging(monkeypatch):
     """Disable logging to Application Insight"""
-    monkeypatch.setattr("datareservoirio.client.AzureLogHandler", logging.NullHandler())
+
+
+#    monkeypatch.setattr("datareservoirio.client.AzureLogHandler", logging.NullHandler())
 
 
 @pytest.fixture

--- a/tests/test__logging.py
+++ b/tests/test__logging.py
@@ -25,8 +25,8 @@ def my_class():
     my_class = my_test_class()
     my_class.logging_as_exception = False
     my_class.logging_as_warning = False
-    exceptions_logger.exception = types.MethodType(change_logging, my_class)
-    exceptions_logger.warning = types.MethodType(change_logging_warning, my_class)
+    exceptions_logger().exception = types.MethodType(change_logging, my_class)
+    exceptions_logger().warning = types.MethodType(change_logging_warning, my_class)
 
     return my_class
 

--- a/tests/test__logging.py
+++ b/tests/test__logging.py
@@ -3,7 +3,9 @@ import types
 
 import pytest
 
-from datareservoirio._logging import exceptions_logger, log_decorator
+from datareservoirio._logging import get_exceptions_logger, log_decorator
+
+exceptions_logger = get_exceptions_logger()
 
 
 class my_test_class:
@@ -25,8 +27,8 @@ def my_class():
     my_class = my_test_class()
     my_class.logging_as_exception = False
     my_class.logging_as_warning = False
-    exceptions_logger().exception = types.MethodType(change_logging, my_class)
-    exceptions_logger().warning = types.MethodType(change_logging_warning, my_class)
+    exceptions_logger.exception = types.MethodType(change_logging, my_class)
+    exceptions_logger.warning = types.MethodType(change_logging_warning, my_class)
 
     return my_class
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -104,7 +104,7 @@ class Test_Client:
         drio.Client(auth_session, cache=True, cache_opt=cache_opt)
 
     def client_error_handler(self, client, method):
-        exceptions_logger.exception = types.MethodType(change_logging, client)
+        exceptions_logger().exception = types.MethodType(change_logging, client)
         client._auth_session.get = types.MethodType(method, client._auth_session)
         return client
 
@@ -946,7 +946,7 @@ class Test_Client:
 
     def test_client_get_throws_exception_is_logged(self, client):
         client.was_called = False
-        exceptions_logger.exception = types.MethodType(change_logging, client)
+        exceptions_logger().exception = types.MethodType(change_logging, client)
         with pytest.raises(ValueError):
             client.get("e3d82cda-4737-4af9-8d17-d9dfda8703d0", raise_empty=True)
         assert client.was_called == True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,10 +13,12 @@ from requests.exceptions import InvalidJSONError
 from tenacity import RetryError
 
 import datareservoirio as drio
-from datareservoirio._logging import exceptions_logger
+from datareservoirio._logging import get_exceptions_logger
 from datareservoirio._utils import DataHandler
 
 TEST_PATH = Path(__file__).parent
+
+exceptions_logger = get_exceptions_logger()
 
 
 def change_logging(self, msg, *args, exc_info=True, **kwargs):
@@ -104,7 +106,7 @@ class Test_Client:
         drio.Client(auth_session, cache=True, cache_opt=cache_opt)
 
     def client_error_handler(self, client, method):
-        exceptions_logger().exception = types.MethodType(change_logging, client)
+        exceptions_logger.exception = types.MethodType(change_logging, client)
         client._auth_session.get = types.MethodType(method, client._auth_session)
         return client
 
@@ -946,7 +948,7 @@ class Test_Client:
 
     def test_client_get_throws_exception_is_logged(self, client):
         client.was_called = False
-        exceptions_logger().exception = types.MethodType(change_logging, client)
+        exceptions_logger.exception = types.MethodType(change_logging, client)
         with pytest.raises(ValueError):
             client.get("e3d82cda-4737-4af9-8d17-d9dfda8703d0", raise_empty=True)
         assert client.was_called == True


### PR DESCRIPTION
### This PR is related to user story [ESS-3444](https://4insight.atlassian.net/browse/ESS-3444)

## Description
Turn all logging on and off with the  ```DRIO_PYTHON_APPINSIGHTS``` environment variable as pr the docs.
https://docs.4insight.io/dataanalytics/reservoir/python/latest/user_guide/advanced_config.html#instrumentation

Use Open Telemetry package instead of Open Census, Open Census is not working properly with Python 3.13 

[ESS-3444]: https://4insight.atlassian.net/browse/ESS-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ