### PR TITLE
Ess 3466 add read timeout for calls made to azure storage account

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -104,7 +104,9 @@ class Client:
         return response.json()
 
     @log_decorator("exception")
-    def create(self, series=None, wait_on_verification=True, dynamic_read_timeout=False):
+    def create(
+        self, series=None, wait_on_verification=True, dynamic_read_timeout=False
+    ):
         """
         Create a new series in DataReservoir.io from a pandas.Series. If no
         data is provided, an empty series is created.
@@ -127,7 +129,7 @@ class Client:
         dynamic_read_timeout : bool (optional)
             While uploading file there is no timeout for read operations which can cause
             problems when there is no response from the server. If this flag is set to true,
-            application will calculate and apply timeout for read operations and retry upload 
+            application will calculate and apply timeout for read operations and retry upload
             if necessary.
             Default is False.
 
@@ -179,7 +181,9 @@ class Client:
         return response.json()
 
     @log_decorator("exception")
-    def append(self, series, series_id, wait_on_verification=True, dynamic_read_timeout=False):
+    def append(
+        self, series, series_id, wait_on_verification=True, dynamic_read_timeout=False
+    ):
         """
         Append data to an already existing series.
 
@@ -202,7 +206,7 @@ class Client:
         dynamic_read_timeout : bool (optional)
             While uploading file there is no timeout for read operations which can cause
             problems when there is no response from the server. If this flag is set to true,
-            application will calculate and apply timeout for read operations and retry upload 
+            application will calculate and apply timeout for read operations and retry upload
             if necessary.
             Default is False.
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -104,7 +104,7 @@ class Client:
         return response.json()
 
     @log_decorator("exception")
-    def create(self, series=None, wait_on_verification=True):
+    def create(self, series=None, wait_on_verification=True, dynamic_read_timeout=False):
         """
         Create a new series in DataReservoir.io from a pandas.Series. If no
         data is provided, an empty series is created.
@@ -124,6 +124,12 @@ class Client:
             validation is successful. The latter is significantly faster, but
             is recommended when the data is "validated" in advance.
             Default is True.
+        dynamic_read_timeout : bool (optional)
+            While uploading file there is no timeout for read operations which can cause
+            problems when there is no response from the server. If this flag is set to true,
+            application will calculate and apply timeout for read operations and retry upload 
+            if necessary.
+            Default is False.
 
         Returns
         -------
@@ -157,7 +163,7 @@ class Client:
             environment.api_base_url + "files/commit",
             {"json": {"FileId": file_id}, "timeout": _TIMEOUT_DEAULT},
         )
-        self._storage.put(df, target_url, commit_request)
+        self._storage.put(df, target_url, commit_request, dynamic_read_timeout)
 
         if wait_on_verification:
             status = self._wait_until_file_ready(file_id)
@@ -173,7 +179,7 @@ class Client:
         return response.json()
 
     @log_decorator("exception")
-    def append(self, series, series_id, wait_on_verification=True):
+    def append(self, series, series_id, wait_on_verification=True, dynamic_read_timeout=False):
         """
         Append data to an already existing series.
 
@@ -193,6 +199,12 @@ class Client:
             validation is successful. The latter is significantly faster, but
             is recommended when the data is "validated" in advance.
             Default is True.
+        dynamic_read_timeout : bool (optional)
+            While uploading file there is no timeout for read operations which can cause
+            problems when there is no response from the server. If this flag is set to true,
+            application will calculate and apply timeout for read operations and retry upload 
+            if necessary.
+            Default is False.
 
         Returns
         -------
@@ -217,7 +229,7 @@ class Client:
             {"json": {"FileId": file_id}, "timeout": _TIMEOUT_DEAULT},
         )
 
-        self._storage.put(df, target_url, commit_request)
+        self._storage.put(df, target_url, commit_request, dynamic_read_timeout)
 
         if wait_on_verification:
             status = self._wait_until_file_ready(file_id)

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -363,7 +363,7 @@ def _df_to_blob(df, blob_url, session=_BLOBSTORAGE_SESSION, dynamic_read_timeout
 
 
 def _calculate_timeout(file_size_bytes):
-    bytes_per_second = 1 * 1024 * 1024 # 1MB/s
+    bytes_per_second = 0.5 * 1024 * 1024 # 0,5 MB/s
     min_timeout = 30
-    timeout = max(min_timeout, (file_size_bytes / bytes_per_second) * 1.5)
+    timeout = int(max(min_timeout, (file_size_bytes / bytes_per_second) * 1.5)) # 1.5 tolerance
     return timeout

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -357,13 +357,22 @@ def _df_to_blob(df, blob_url, session=_BLOBSTORAGE_SESSION, dynamic_read_timeout
             url=blob_url,
             headers={"x-ms-blob-type": "BlockBlob"},
             data=fp,
-            timeout=(30, _calculate_timeout(fp.getbuffer().nbytes) if dynamic_read_timeout else None),
+            timeout=(
+                30,
+                (
+                    _calculate_timeout(fp.getbuffer().nbytes)
+                    if dynamic_read_timeout
+                    else None
+                ),
+            ),
         ).raise_for_status()
     return
 
 
 def _calculate_timeout(file_size_bytes):
-    bytes_per_second = 0.5 * 1024 * 1024 # 0,5 MB/s
+    bytes_per_second = 0.5 * 1024 * 1024  # 0,5 MB/s
     min_timeout = 30
-    timeout = int(max(min_timeout, (file_size_bytes / bytes_per_second) * 1.5)) # 1.5 tolerance
+    timeout = int(
+        max(min_timeout, (file_size_bytes / bytes_per_second) * 1.5)
+    )  # 1.5 tolerance
     return timeout

--- a/datareservoirio/storage/storage.py
+++ b/datareservoirio/storage/storage.py
@@ -59,7 +59,7 @@ class Storage:
 
         self._session = session
 
-    def put(self, df, target_url, commit_request):
+    def put(self, df, target_url, commit_request, dynamic_read_timeout=False):
         """
         Put a Pandas DataFrame into storage.
 
@@ -72,9 +72,12 @@ class Storage:
         commit_request : tuple
             Parameteres for "commit" request. Given as `(METHOD, URL, kwargs)`.
             The tuple is passed forward to `session.request(method=METHOD, url=URL, **kwargs)`
+        dynamic_read_timeout : bool
+            Flag that enables timeout calculation for read operation while
+            uploading file
 
         """
-        _df_to_blob(df, target_url)
+        _df_to_blob(df, target_url, _BLOBSTORAGE_SESSION, dynamic_read_timeout)
 
         method, url, kwargs = commit_request
         response = self._session.request(method=method, url=url, **kwargs)
@@ -322,7 +325,7 @@ def _blob_to_df(blob_url, session=_BLOBSTORAGE_SESSION):
     return df
 
 
-def _df_to_blob(df, blob_url, session=_BLOBSTORAGE_SESSION):
+def _df_to_blob(df, blob_url, session=_BLOBSTORAGE_SESSION, dynamic_read_timeout=False):
     """
     Upload a Pandas Dataframe as blob to a remote storage.
 
@@ -354,6 +357,13 @@ def _df_to_blob(df, blob_url, session=_BLOBSTORAGE_SESSION):
             url=blob_url,
             headers={"x-ms-blob-type": "BlockBlob"},
             data=fp,
-            timeout=(30, None),
+            timeout=(30, _calculate_timeout(fp.getbuffer().nbytes) if dynamic_read_timeout else None),
         ).raise_for_status()
     return
+
+
+def _calculate_timeout(file_size_bytes):
+    bytes_per_second = 1 * 1024 * 1024 # 1MB/s
+    min_timeout = 30
+    timeout = max(min_timeout, (file_size_bytes / bytes_per_second) * 1.5)
+    return timeout

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -4,8 +4,8 @@ import time
 from pathlib import Path
 from unittest.mock import ANY, call
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
 import requests
 from requests import HTTPError

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import ANY, call
 
 import pandas as pd
+import numpy as np
 import pytest
 import requests
 from requests import HTTPError
@@ -16,6 +17,24 @@ from datareservoirio.storage.cache_engine import CacheIO
 
 TEST_PATH = Path(__file__).parent
 
+def helper_function(func):
+    func._is_helper = True
+    return func
+
+@helper_function
+def generate_dataframe(target_bytes):
+    NUM_COLUMNS = 5
+    BYTES_PER_VALUE = 28  
+    
+    bytes_per_row = NUM_COLUMNS * BYTES_PER_VALUE
+    num_rows = max(1, int(target_bytes / bytes_per_row))
+    
+    data = {
+        f'col_{i}': np.random.randn(num_rows)
+        for i in range(NUM_COLUMNS)
+    }
+    
+    return pd.DataFrame(data)
 
 class Test__blob_to_df:
     """
@@ -553,6 +572,119 @@ class Test_Storage:
             mock_requests.call_args_list[0].kwargs["data"].memory
             == data.as_binary_csv()
         )
+
+        mock_requests.assert_has_calls(calls_expected)
+
+    def test_put_dynamic_timeout_sets_correct_value(
+        self,
+        mock_requests,
+        storage_no_cache,
+        response_cases,
+    ):
+        response_cases.set("group4")
+        df = generate_dataframe(20_000_000) # 20 MB
+
+        storage_no_cache.put(
+            df,
+            "http://example/blob/url",
+            (
+                "POST",
+                "https://reservoir-api.4subsea.net/api/files/commit",
+                {"json": {"FileId": "1234"}, "timeout": 10},
+            ),
+            True,
+        )
+
+        calls_expected = [
+            call(
+                method="put",
+                url="http://example/blob/url",
+                headers={"x-ms-blob-type": "BlockBlob"},
+                data=ANY,
+                timeout=(30, 40),
+            ),
+            call(
+                method="POST",
+                url="https://reservoir-api.4subsea.net/api/files/commit",
+                json={"FileId": "1234"},
+                timeout=10,
+            ),
+        ]
+
+        mock_requests.assert_has_calls(calls_expected)
+
+    def test_put_dynamic_timeout_sets_minimal_value(
+        self,
+        mock_requests,
+        storage_no_cache,
+        response_cases,
+    ):
+        response_cases.set("group4")
+        df = generate_dataframe(1_000_000) # 1 MB
+
+        storage_no_cache.put(
+            df,
+            "http://example/blob/url",
+            (
+                "POST",
+                "https://reservoir-api.4subsea.net/api/files/commit",
+                {"json": {"FileId": "1234"}, "timeout": 10},
+            ),
+            True,
+        )
+
+        calls_expected = [
+            call(
+                method="put",
+                url="http://example/blob/url",
+                headers={"x-ms-blob-type": "BlockBlob"},
+                data=ANY,
+                timeout=(30, 30),
+            ),
+            call(
+                method="POST",
+                url="https://reservoir-api.4subsea.net/api/files/commit",
+                json={"FileId": "1234"},
+                timeout=10,
+            ),
+        ]
+
+        mock_requests.assert_has_calls(calls_expected)
+
+    def test_put_without_dynamic_timeout_doesnt_set_its_value(
+        self,
+        mock_requests,
+        storage_no_cache,
+        response_cases,
+    ):
+        response_cases.set("group4")
+        df = generate_dataframe(20_000_000) # 20 MB
+
+        storage_no_cache.put(
+            df,
+            "http://example/blob/url",
+            (
+                "POST",
+                "https://reservoir-api.4subsea.net/api/files/commit",
+                {"json": {"FileId": "1234"}, "timeout": 10},
+            )
+        )
+
+        calls_expected = [
+            call(
+                method="put",
+                url="http://example/blob/url",
+                headers={"x-ms-blob-type": "BlockBlob"},
+                data=ANY,
+                timeout=(30, None),
+            ),
+            call(
+                method="POST",
+                url="https://reservoir-api.4subsea.net/api/files/commit",
+                json={"FileId": "1234"},
+                timeout=10,
+            ),
+        ]
 
         mock_requests.assert_has_calls(calls_expected)
 

--- a/tests/test_storage/test_storage.py
+++ b/tests/test_storage/test_storage.py
@@ -17,24 +17,24 @@ from datareservoirio.storage.cache_engine import CacheIO
 
 TEST_PATH = Path(__file__).parent
 
+
 def helper_function(func):
     func._is_helper = True
     return func
 
+
 @helper_function
 def generate_dataframe(target_bytes):
     NUM_COLUMNS = 5
-    BYTES_PER_VALUE = 28  
-    
+    BYTES_PER_VALUE = 28
+
     bytes_per_row = NUM_COLUMNS * BYTES_PER_VALUE
     num_rows = max(1, int(target_bytes / bytes_per_row))
-    
-    data = {
-        f'col_{i}': np.random.randn(num_rows)
-        for i in range(NUM_COLUMNS)
-    }
-    
+
+    data = {f"col_{i}": np.random.randn(num_rows) for i in range(NUM_COLUMNS)}
+
     return pd.DataFrame(data)
+
 
 class Test__blob_to_df:
     """
@@ -582,7 +582,7 @@ class Test_Storage:
         response_cases,
     ):
         response_cases.set("group4")
-        df = generate_dataframe(20_000_000) # 20 MB
+        df = generate_dataframe(20_000_000)  # 20 MB
 
         storage_no_cache.put(
             df,
@@ -620,7 +620,7 @@ class Test_Storage:
         response_cases,
     ):
         response_cases.set("group4")
-        df = generate_dataframe(1_000_000) # 1 MB
+        df = generate_dataframe(1_000_000)  # 1 MB
 
         storage_no_cache.put(
             df,
@@ -658,7 +658,7 @@ class Test_Storage:
         response_cases,
     ):
         response_cases.set("group4")
-        df = generate_dataframe(20_000_000) # 20 MB
+        df = generate_dataframe(20_000_000)  # 20 MB
 
         storage_no_cache.put(
             df,
@@ -667,7 +667,7 @@ class Test_Storage:
                 "POST",
                 "https://reservoir-api.4subsea.net/api/files/commit",
                 {"json": {"FileId": "1234"}, "timeout": 10},
-            )
+            ),
         )
 
         calls_expected = [


### PR DESCRIPTION
### This PR is related to user story [ESS-3466](https://4insight.atlassian.net/browse/ESS-3466)

## Description
Add dynamic_read_timeout parameter to calculate timeout value in order to stop and retry operation when connection to server is lost for functions that upload files to Azure Storage Account 

- client.create
- client.append



  



[ESS-3466]: https://4insight.atlassian.net/browse/ESS-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ