### PR TITLE
ESS-3589: Pinning azure-monitor-opentelemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "tenacity<8.5",
   "urllib3 > 2",
   "tqdm",
-  "azure-monitor-opentelemetry",
+  "azure-monitor-opentelemetry==1.6.12",
 ]
 
 [project.urls]


### PR DESCRIPTION
### This PR is related to user story [ESS-3580](https://4insight.atlassian.net/browse/ESS-3580)

## Description
This PR pins the azure-monitor-opentelemetry package to 1.6.12 as the latest (1.6.13) has a bug, leading to an error about missing psycopg2 module. This issue will be fixed in 1.6.14 according to their [changelog](https://github.com/Azure/azure-sdk-for-python/pull/42342#1614-unreleased) and the dependecy will be unpinned then. 



[ESS-3580]: https://4insight.atlassian.net/browse/ESS-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ