### PR TITLE
Fix/Invalid escape sequence, 

### DIFF
--- a/datareservoirio/appdirs.py
+++ b/datareservoirio/appdirs.py
@@ -96,7 +96,7 @@ def user_data_dir(appname, roaming=False):
         Win XP (roaming):       C:\\Documents and Settings\\<username>\\Local ...
                                 ...Settings\\Application Data\\<AppName>
         Win 7  (not roaming):   C:\\Users\\<username>\\AppData\\Local\\<AppName>
-        Win 7  (roaming):       C:\\Users\\<username>\\AppData\\\Roaming\\<AppName>
+        Win 7  (roaming):       C:\\Users\\<username>\\AppData\\Roaming\\<AppName>
 
     For Unix, we follow the XDG spec and support $XDG_DATA_HOME.
     That means, by default '~/.local/share/<AppName>'.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "DataReservoir.io Python API"
 readme = "README.rst"
 license = { file = "LICENSE" }
-requires-python = ">3.11"
+requires-python = ">=3.11, <4"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
### This PR is unrelated to a user story

## Description
* #138 mistakenly omits 3.11 as a valid python version in the toml file, by declaring valid python version as strictly greater than 3.11. The documentation states that 3.11, 3.12 and 3.13 are officially supported - this is fixed
* #142 inadvertently introduced one invalid escape sequence in the docstring, causing warnings in tests - this is fixed

