### PR TITLE
ESS-3751: Extracted azure monitor config into own function with lock

### DIFF
--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -35,7 +35,8 @@ def get_exceptions_logger() -> logging.Logger:
         if enable_app_insights == "true" or enable_app_insights == "1":
             _ensure_azure_monitor_configured(
                 connection_string=environment._application_insight_connectionstring,
-                logger_name=__name__ + "_exception_logger")
+                logger_name=__name__ + "_exception_logger"
+            )
             exceptions_logger.setLevel("WARNING")
 
     return exceptions_logger

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -35,7 +35,7 @@ def get_exceptions_logger() -> logging.Logger:
         if enable_app_insights == "true" or enable_app_insights == "1":
             _ensure_azure_monitor_configured(
                 connection_string=environment._application_insight_connectionstring,
-                logger_name=__name__ + "_exception_appinsight")
+                logger_name=__name__ + "_exception_logger")
             exceptions_logger.setLevel("WARNING")
 
     return exceptions_logger

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -33,8 +33,9 @@ def get_exceptions_logger() -> logging.Logger:
     if os.getenv(ENV_VAR_ENABLE_APP_INSIGHTS) is not None:
         enable_app_insights = os.environ[ENV_VAR_ENABLE_APP_INSIGHTS].lower()
         if enable_app_insights == "true" or enable_app_insights == "1":
-            _ensure_azure_monitor_configured(connection_string=environment._application_insight_connectionstring,
-                                     logger_name=__name__ + "_exception_appinsight")
+            _ensure_azure_monitor_configured(
+                connection_string=environment._application_insight_connectionstring,
+                logger_name=__name__ + "_exception_appinsight")
             exceptions_logger.setLevel("WARNING")
 
     return exceptions_logger

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -35,7 +35,7 @@ def get_exceptions_logger() -> logging.Logger:
         if enable_app_insights == "true" or enable_app_insights == "1":
             _ensure_azure_monitor_configured(
                 connection_string=environment._application_insight_connectionstring,
-                logger_name=__name__ + "_exception_logger"
+                logger_name=__name__ + "_exceptions_logger"
             )
             exceptions_logger.setLevel("WARNING")
 

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -1,7 +1,7 @@
 import logging
 import os
-from functools import lru_cache, wraps
 import threading
+from functools import lru_cache, wraps
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 
@@ -10,18 +10,20 @@ import datareservoirio as drio
 from ._constants import ENV_VAR_ENABLE_APP_INSIGHTS, ENV_VAR_ENGINE_ROOM_APP_ID
 from .globalsettings import environment
 
-
 _configure_lock = threading.Lock()
 _configured_loggers = {}
 
+
 def _ensure_azure_monitor_configured(connection_string, logger_name):
     cache_key = (connection_string, logger_name)
-    
+
     if cache_key not in _configured_loggers:
         with _configure_lock:
             # Double-check locking
             if cache_key not in _configured_loggers:
-                configure_azure_monitor(connection_string=connection_string, logger_name=logger_name)
+                configure_azure_monitor(
+                    connection_string=connection_string, logger_name=logger_name
+                )
                 _configured_loggers[cache_key] = True
 
 

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -1,6 +1,7 @@
 import logging
 import os
-from functools import cache, wraps
+from functools import lru_cache, wraps
+import threading
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 
@@ -10,18 +11,32 @@ from ._constants import ENV_VAR_ENABLE_APP_INSIGHTS, ENV_VAR_ENGINE_ROOM_APP_ID
 from .globalsettings import environment
 
 
-@cache
+_configure_lock = threading.Lock()
+_configured_loggers = {}
+
+def _ensure_azure_monitor_configured(connection_string, logger_name):
+    cache_key = (connection_string, logger_name)
+    
+    if cache_key not in _configured_loggers:
+        with _configure_lock:
+            # Double-check inside lock
+            if cache_key not in _configured_loggers:
+                configure_azure_monitor(connection_string=connection_string, logger_name=logger_name)
+                _configured_loggers[cache_key] = True
+
+
+@lru_cache(maxsize=1)
 def get_exceptions_logger() -> logging.Logger:
+    print("bruh", flush=True)
+    logging.log(logging.INFO, 'foobar')
     exceptions_logger = logging.getLogger(__name__ + "_exception_logger")
     exceptions_logger.setLevel(logging.DEBUG)
 
     if os.getenv(ENV_VAR_ENABLE_APP_INSIGHTS) is not None:
         enable_app_insights = os.environ[ENV_VAR_ENABLE_APP_INSIGHTS].lower()
         if enable_app_insights == "true" or enable_app_insights == "1":
-            configure_azure_monitor(
-                connection_string=environment._application_insight_connectionstring,
-                logger_name=__name__ + "_exceptions_logger",
-            )
+            _ensure_azure_monitor_configured(connection_string=environment._application_insight_connectionstring,
+                                     logger_name=__name__ + "_exception_appinsight")
             exceptions_logger.setLevel("WARNING")
 
     return exceptions_logger

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -35,7 +35,7 @@ def get_exceptions_logger() -> logging.Logger:
         if enable_app_insights == "true" or enable_app_insights == "1":
             _ensure_azure_monitor_configured(
                 connection_string=environment._application_insight_connectionstring,
-                logger_name=__name__ + "_exceptions_logger"
+                logger_name=__name__ + "_exceptions_logger",
             )
             exceptions_logger.setLevel("WARNING")
 

--- a/datareservoirio/_logging.py
+++ b/datareservoirio/_logging.py
@@ -19,7 +19,7 @@ def _ensure_azure_monitor_configured(connection_string, logger_name):
     
     if cache_key not in _configured_loggers:
         with _configure_lock:
-            # Double-check inside lock
+            # Double-check locking
             if cache_key not in _configured_loggers:
                 configure_azure_monitor(connection_string=connection_string, logger_name=logger_name)
                 _configured_loggers[cache_key] = True
@@ -27,8 +27,6 @@ def _ensure_azure_monitor_configured(connection_string, logger_name):
 
 @lru_cache(maxsize=1)
 def get_exceptions_logger() -> logging.Logger:
-    print("bruh", flush=True)
-    logging.log(logging.INFO, 'foobar')
     exceptions_logger = logging.getLogger(__name__ + "_exception_logger")
     exceptions_logger.setLevel(logging.DEBUG)
 

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -344,7 +344,7 @@ class Client:
 
         return wrapper
 
-    # @log_decorator("exception")
+    @log_decorator("exception")
     @_timer
     @retry(
         stop=stop_after_attempt(
@@ -361,7 +361,7 @@ class Client:
         ),
         wait=wait_chain(*[wait_fixed(0.1), wait_fixed(0.5), wait_fixed(30)]),
     )
-    # @log_decorator("warning")
+    @log_decorator("warning")
     def get(
         self,
         series_id,

--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -5,7 +5,7 @@ import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from functools import cache, wraps
+from functools import lru_cache, wraps
 from operator import itemgetter
 from urllib.parse import urlencode
 from uuid import uuid4
@@ -25,7 +25,7 @@ from tqdm.auto import tqdm
 
 from datareservoirio._constants import ENV_VAR_ENABLE_APP_INSIGHTS
 
-from ._logging import log_decorator
+from ._logging import _ensure_azure_monitor_configured, log_decorator
 from ._utils import function_translation, period_translation
 from .globalsettings import environment
 from .storage import Storage
@@ -33,14 +33,14 @@ from .storage import Storage
 log = logging.getLogger(__name__)
 
 
-@cache
+@lru_cache(maxsize=1)
 def metric() -> logging.Logger:
     logger = logging.getLogger(__name__ + "_metric_appinsight")
     if os.getenv(ENV_VAR_ENABLE_APP_INSIGHTS) is not None:
         enable_app_insights = os.environ[ENV_VAR_ENABLE_APP_INSIGHTS].lower()
         if enable_app_insights == "true" or enable_app_insights == "1":
             logger.setLevel(logging.DEBUG)
-            configure_azure_monitor(
+            _ensure_azure_monitor_configured(
                 connection_string=environment._application_insight_connectionstring,
                 logger_name=__name__ + "_metric_appinsight",
             )
@@ -344,7 +344,7 @@ class Client:
 
         return wrapper
 
-    @log_decorator("exception")
+    # @log_decorator("exception")
     @_timer
     @retry(
         stop=stop_after_attempt(
@@ -361,7 +361,7 @@ class Client:
         ),
         wait=wait_chain(*[wait_fixed(0.1), wait_fixed(0.5), wait_fixed(30)]),
     )
-    @log_decorator("warning")
+    # @log_decorator("warning")
     def get(
         self,
         series_id,


### PR DESCRIPTION
### This PR is related to user story [ESS-3751](https://4insight.atlassian.net/browse/ESS-3751)

## Description
Get rid of warnings about multiple definitions of telemetry objects when calling client methods (especially `.get`/`.get_samples_aggregate`) in parallel.
  



[ESS-3751]: https://4insight.atlassian.net/browse/ESS-3751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ