### PR TITLE
DM-1490 Expose range/end endpoint

### DIFF
--- a/datareservoirio/client.py
+++ b/datareservoirio/client.py
@@ -847,6 +847,35 @@ class Client:
         response.raise_for_status()
         return
 
+    def range_end(self, timeseriesIds):
+        """
+        Retrieve single latest end date of a set of timeseries ids.
+
+        Parameters
+        ----------
+        timeseriesIds : list or str
+            List of timeseries ids or aliases, or a single timeseries id or alias.
+
+        Returns
+        -------
+        dict
+            Ranges. None if none of the series are found.
+        """
+
+        if isinstance(timeseriesIds, str):
+            timeseriesIds = [timeseriesIds]
+
+        base_url = environment.api_base_url +"reservoir/timeseries/samples/aggregate/range/end"
+        params = [("timeSeriesIdsOrAliases", ts) for ts in timeseriesIds]
+
+        url = f"{base_url}?{urlencode(params)}"
+        response = self._auth_session.get(
+            url,
+            timeout=_TIMEOUT_DEAULT,
+        )
+        response.raise_for_status()
+        return response.json()
+    
     def _verify_and_prepare_series(self, series):
         if not isinstance(series, pd.Series):
             raise ValueError("series must be a pandas Series")


### PR DESCRIPTION
### This PR is related to user story [DM-1490]([url_to_jira_task](https://4insight.atlassian.net/browse/DM-1490))

## Description
Expose existing reservoir endpoint range/end in client.py
This helps us set the start and end times for plots in the Swim stack angles dashboard.  If we know the maximum latest data point for the data on a plot, we can set the start and end times based on the desired range
Example:  User wants the latest 6 hours of data.  We can start from now and show them the past 6 hours - but that doesn't work if the data stopped streaming last week.  In that case, they want to see the most recent 6 hours, ie starting from a week ago and counting back 6 hours.  For this we need to know range/end for the datapoints.
Since an existing handy api endpoint already exists for this, it would be nice to expose it in the Drio client.

## Checklist
- [ ] PR title is descriptive and fit for injection into release notes (see tips below)
- [ ] Correct label(s) are used


  



[DM-1490]: https://4insight.atlassian.net/browse/DM-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ